### PR TITLE
fix: use platformVersion instead of min*Version linker flag for xcode 15

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ shared module and access them in Kotlin via `cinterop` for iOS targets. It is us
 * Creating a Kotlin-Friendly Swift API
 * Learning how Swift <-> Kotlin interoperability works
 
-**Note:** _Plugin has been tested on Gradle 7.5+, Xcode 13+_
+**Note:** _Plugin has been tested on Gradle 7.5+, Xcode 15+_
 
 ## Installation
 

--- a/plugin/src/main/kotlin/io/github/ttypic/swiftklib/gradle/task/CompileSwiftTask.kt
+++ b/plugin/src/main/kotlin/io/github/ttypic/swiftklib/gradle/task/CompileSwiftTask.kt
@@ -179,7 +179,7 @@ open class CompileSwiftTask @Inject constructor(
             staticLibraries = ${libPath.name}
             libraryPaths = ${libPath.parentFile.absolutePath}
 
-            linkerOpts = -L/usr/lib/swift -${compileTarget.linkerMinOsVersionName()} ${minOs(compileTarget)}.0 -L/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift/${compileTarget.os()}
+            linkerOpts = -L/usr/lib/swift -${compileTarget.linkerPlatformVersionName()} ${minOs(compileTarget)}.0 ${minOs(compileTarget)}.0 -L/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift/${compileTarget.os()}
         """.trimIndent()
         defFile.create(content)
     }

--- a/plugin/src/main/kotlin/io/github/ttypic/swiftklib/gradle/task/CompileTargetExt.kt
+++ b/plugin/src/main/kotlin/io/github/ttypic/swiftklib/gradle/task/CompileTargetExt.kt
@@ -49,16 +49,12 @@ internal fun CompileTarget.simulatorSuffix() = when(this) {
     CompileTarget.macosArm64 -> ""
 }
 
-internal fun CompileTarget.linkerMinOsVersionName() = when(this) {
-    CompileTarget.iosX64 -> "ios_simulator_version_min"
-    CompileTarget.iosArm64 -> "ios_version_min"
-    CompileTarget.iosSimulatorArm64 -> "ios_simulator_version_min"
-    CompileTarget.watchosX64 -> "watchos_simulator_version_min"
-    CompileTarget.watchosArm64 -> "watchos_version_min"
-    CompileTarget.watchosSimulatorArm64 -> "watchos_simulator_version_min"
-    CompileTarget.tvosX64 -> "tvos_simulator_version_min"
-    CompileTarget.tvosArm64 -> "tvos_version_min"
-    CompileTarget.tvosSimulatorArm64 -> "tvos_simulator_version_min"
-    CompileTarget.macosX64 -> "macosx_version_min"
-    CompileTarget.macosArm64 -> "macosx_version_min"
+internal fun CompileTarget.linkerPlatformVersionName() = when(this) {
+    CompileTarget.iosArm64 -> "platform_version ios"
+    CompileTarget.iosX64, CompileTarget.iosSimulatorArm64 -> "platform_version ios-simulator"
+    CompileTarget.watchosArm64 -> "platform_version watchos"
+    CompileTarget.watchosX64, CompileTarget.watchosSimulatorArm64 -> "platform_version watchos-simulator"
+    CompileTarget.tvosArm64 -> "platform_version tvos"
+    CompileTarget.tvosX64, CompileTarget.tvosSimulatorArm64 -> "platform_version tvos-simulator"
+    CompileTarget.macosX64, CompileTarget.macosArm64 -> "platform_version macosx"
 }


### PR DESCRIPTION
Xcode 15 introduced a new linker that appearently removes the `ios_version_min` etc. flags and replaces it with `-platform_version`

From manpage:
```     
-platform_version platform min_version sdk_version
             This is set to indicate the platform, oldest supported version of that platform that output is to be used on, and the SDK that the output was built against.  platform is a
             numeric value as defined in <mach-o/loader.h>, or it may be one of the following strings:
             • macos
             • ios
             • tvos
             • watchos
             • bridgeos
             • visionos
             • xros
             • mac-catalyst
             • ios-simulator
             • tvos-simulator
             • watchos-simulator
             • visionos-simulator
             • xros-simulator
             • driverkit
             Specifying a newer min or SDK version enables the linker to assume features of that OS or SDK in the output file. The format of min_version and sdk_version is a version number
             such as 10.13 or 10.14
```

This commit fixes builds with XCode 15.