### PR TITLE
fix: more robust readXcodeMajorVersion

### DIFF
--- a/plugin/src/main/kotlin/io/github/ttypic/swiftklib/gradle/task/CompileSwiftTask.kt
+++ b/plugin/src/main/kotlin/io/github/ttypic/swiftklib/gradle/task/CompileSwiftTask.kt
@@ -178,7 +178,7 @@ open class CompileSwiftTask @Inject constructor(
         }
 
         val output = stdout.toString().trim()
-        val (_, majorVersion) = "Xcode (\\d+)\\.\\d+\\.\\d+".toRegex().find(output)?.groupValues
+        val (_, majorVersion) = "Xcode (\\d+)\\..*".toRegex().find(output)?.groupValues
             ?: throw IllegalStateException("Can't find Xcode")
 
         return majorVersion.toInt()


### PR DESCRIPTION
Hi, I've got another PR.
I tested version 0.5.0 and got the error "Can't find Xcode".
Output of xcodebuild -version is:
```
xcodebuild -version
Xcode 15.0
Build version 15A240d
```

So the regex didn't match. I guess it should be more robust to match more version strings (there could be special strings for RC's as well).