### PR TITLE
Support locally defined `Package.swift` in native directory

### DIFF
--- a/plugin/src/main/kotlin/io/github/ttypic/swiftklib/gradle/task/CompileSwiftTask.kt
+++ b/plugin/src/main/kotlin/io/github/ttypic/swiftklib/gradle/task/CompileSwiftTask.kt
@@ -72,6 +72,15 @@ open class CompileSwiftTask @Inject constructor(
 
         swiftBuildDir.mkdirs()
         path.copyRecursively(File(swiftBuildDir, cinteropName), true)
+
+        // Check if Package.swift exists in the cinteropName directory
+        val packageSwiftFile = File(path, "Package.swift")
+        if (packageSwiftFile.exists()) {
+            packageSwiftFile.copyTo(File(swiftBuildDir, "Package.swift"), overwrite = true)
+        } else {
+            // call createPackageSwift() if Package.swift does not exist
+            createPackageSwift()
+        }
     }
 
     /**


### PR DESCRIPTION
Opening the PR to start discussion as possible option to enable adding locally defined package which can be worked on independently and have their own dependencies.