### PR TITLE
Prettify swift build output

### DIFF
--- a/plugin/src/main/kotlin/io/github/ttypic/swiftklib/gradle/templates/CreatePackageSwift.kt
+++ b/plugin/src/main/kotlin/io/github/ttypic/swiftklib/gradle/templates/CreatePackageSwift.kt
@@ -1,0 +1,25 @@
+package io.github.ttypic.swiftklib.gradle.templates
+
+internal fun createPackageSwiftContents(
+    cinteropName: String,
+): String = """
+    // swift-tools-version:5.5
+    import PackageDescription
+
+    let package = Package(
+        name: "$cinteropName",
+        products: [
+            .library(
+                name: "$cinteropName",
+                type: .static,
+                targets: ["$cinteropName"])
+        ],
+        dependencies: [],
+        targets: [
+            .target(
+                name: "$cinteropName",
+                dependencies: [],
+                path: "$cinteropName")
+        ]
+    )
+""".trimIndent()

--- a/plugin/src/main/kotlin/io/github/ttypic/swiftklib/gradle/util/StringReplacingOutputStream.kt
+++ b/plugin/src/main/kotlin/io/github/ttypic/swiftklib/gradle/util/StringReplacingOutputStream.kt
@@ -1,0 +1,62 @@
+package io.github.ttypic.swiftklib.gradle.util
+
+import java.io.BufferedReader
+import java.io.BufferedWriter
+import java.io.OutputStream
+import java.io.OutputStreamWriter
+import java.io.StringReader
+import java.io.StringWriter
+
+internal class StringReplacingOutputStream(
+    private val delegate: OutputStream,
+    private val replacements: Map<String, String>,
+) : OutputStream() {
+    private val stringWriter = StringWriter()
+    private val bufferedWriter = BufferedWriter(stringWriter)
+
+    override fun write(b: Int) {
+        bufferedWriter.write(b)
+        if (b == '\n'.code) {
+            flushLine()
+        }
+    }
+
+    override fun write(b: ByteArray, off: Int, len: Int) {
+        val str = String(b, off, len, Charsets.UTF_8)
+        bufferedWriter.write(str)
+        if (str.contains('\n')) {
+            flushLine()
+        }
+    }
+
+    private fun flushLine() {
+        bufferedWriter.flush()
+        val content = stringWriter.toString()
+        val reader = BufferedReader(StringReader(content))
+        val outputWriter = OutputStreamWriter(delegate, Charsets.UTF_8)
+
+        reader
+            .lineSequence()
+            .forEach { line ->
+                var replacedLine = line
+                replacements.forEach { (key, value) ->
+                    replacedLine = replacedLine.replace(key, value)
+                }
+                outputWriter.write(replacedLine)
+                outputWriter.write('\n'.code)
+            }
+
+        outputWriter.flush()
+        stringWriter.buffer.setLength(0)
+    }
+
+    override fun flush() {
+        flushLine()
+        delegate.flush()
+    }
+
+    override fun close() {
+        flushLine()
+        delegate.close()
+    }
+}


### PR DESCRIPTION
Replace file paths in `swift build` output to point to original source files instead of copied to build dir ones.
Before:
<img width="852" alt="image" src="https://github.com/ttypic/swift-klib-plugin/assets/668727/f7cea978-e2b1-45b5-9e33-f025b6c8c0fe">
After:
<img width="817" alt="image" src="https://github.com/ttypic/swift-klib-plugin/assets/668727/ab9a6a46-1fdf-4373-9f68-882fb58e580a">
