### PR TITLE
Use locally defined `Package.swift`

### DIFF
--- a/plugin/build.gradle.kts
+++ b/plugin/build.gradle.kts
@@ -1,12 +1,12 @@
 plugins {
     id("java-gradle-plugin")
-    id("com.gradle.plugin-publish") version "1.1.0"
-    kotlin("jvm") version "1.9.22"
+    id("com.gradle.plugin-publish") version "1.2.1"
+    kotlin("jvm") version "1.9.10"
 }
 
 dependencies {
     implementation(gradleApi())
-    implementation("org.jetbrains.kotlin:kotlin-gradle-plugin:1.9.22")
+    implementation("org.jetbrains.kotlin:kotlin-gradle-plugin:1.9.10")
 }
 
 version = "0.5.2"

--- a/plugin/build.gradle.kts
+++ b/plugin/build.gradle.kts
@@ -1,12 +1,12 @@
 plugins {
     id("java-gradle-plugin")
     id("com.gradle.plugin-publish") version "1.2.1"
-    kotlin("jvm") version "1.9.10"
+    kotlin("jvm") version "1.9.23"
 }
 
 dependencies {
     implementation(gradleApi())
-    implementation("org.jetbrains.kotlin:kotlin-gradle-plugin:1.9.10")
+    implementation("org.jetbrains.kotlin:kotlin-gradle-plugin:1.9.23")
 }
 
 version = "0.5.2"

--- a/plugin/build.gradle.kts
+++ b/plugin/build.gradle.kts
@@ -1,19 +1,19 @@
 plugins {
     id("java-gradle-plugin")
     id("com.gradle.plugin-publish") version "1.1.0"
-    kotlin("jvm") version "1.7.22"
+    kotlin("jvm") version "1.9.22"
 }
 
 dependencies {
     implementation(gradleApi())
-    implementation("org.jetbrains.kotlin:kotlin-gradle-plugin:1.7.22")
+    implementation("org.jetbrains.kotlin:kotlin-gradle-plugin:1.9.22")
 }
 
-version = "0.5.1"
+version = "0.5.2"
 group = "io.github.ttypic"
 
 kotlin {
-    jvmToolchain(8)
+    jvmToolchain(17)
 }
 
 gradlePlugin {

--- a/plugin/src/main/kotlin/io/github/ttypic/swiftklib/gradle/task/CompileSwiftTask.kt
+++ b/plugin/src/main/kotlin/io/github/ttypic/swiftklib/gradle/task/CompileSwiftTask.kt
@@ -5,6 +5,7 @@ import io.github.ttypic.swiftklib.gradle.EXTENSION_NAME
 import org.gradle.api.DefaultTask
 import org.gradle.api.provider.Property
 import org.gradle.api.tasks.*
+import org.jetbrains.kotlin.konan.target.Platform
 import java.io.ByteArrayOutputStream
 import java.io.File
 import java.lang.IllegalStateException
@@ -39,6 +40,11 @@ open class CompileSwiftTask @Inject constructor(
 
     @TaskAction
     fun produce() {
+        if(!org.gradle.internal.impldep.com.sun.jna.Platform.isMac())
+        {
+            project.logger.warn("Not running on MacOS. Skipping Swift Klib generation")
+            return
+        }
         val packageName: String = packageNameProperty.get()
 
         prepareBuildDirectory()

--- a/plugin/src/main/kotlin/io/github/ttypic/swiftklib/gradle/task/CompileSwiftTask.kt
+++ b/plugin/src/main/kotlin/io/github/ttypic/swiftklib/gradle/task/CompileSwiftTask.kt
@@ -2,6 +2,7 @@ package io.github.ttypic.swiftklib.gradle.task
 
 import io.github.ttypic.swiftklib.gradle.CompileTarget
 import io.github.ttypic.swiftklib.gradle.EXTENSION_NAME
+import org.apache.tools.ant.taskdefs.condition.Os
 import org.gradle.api.DefaultTask
 import org.gradle.api.provider.Property
 import org.gradle.api.tasks.*
@@ -40,7 +41,7 @@ open class CompileSwiftTask @Inject constructor(
 
     @TaskAction
     fun produce() {
-        if(!org.gradle.internal.impldep.com.sun.jna.Platform.isMac())
+        if(!Os.isFamily(Os.FAMILY_MAC))
         {
             project.logger.warn("Not running on MacOS. Skipping Swift Klib generation")
             return


### PR DESCRIPTION
This change makes it possible to work in a swift package independently which makes development much easier with Swift native code. 

Rather than copying contents and generating `Package.swift` we can open our package in Xcode.app and manage dependencies.

Will supply more info. 

<img width="1127" alt="image" src="https://github.com/ttypic/swift-klib-plugin/assets/274318/abd1e771-3b68-4661-be24-65fb29e07a11">
