### PR TITLE
Use clang modules in cinterop instead of headers

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -3,9 +3,18 @@ kotlin = "2.0.0"
 
 gradlePublishPlugin = "1.2.1"
 
+junit-jupiter = "5.8.0"
+
+kotest = "5.9.1"
+
 [libraries]
 
 plugin-kotlin = { module = "org.jetbrains.kotlin:kotlin-gradle-plugin", version.ref = "kotlin" }
+
+test-junit-jupiter = { module = "org.junit.jupiter:junit-jupiter", version.ref = "junit-jupiter" }
+test-junit-jupiter-launcher = { module = "org.junit.jupiter:junit-jupiter-engine" }
+test-kotest-assertions = { module = "io.kotest:kotest-assertions-core", version.ref = "kotest" }
+
 
 [plugins]
 kotlin-jvm = { id = "org.jetbrains.kotlin.jvm", version.ref = "kotlin" }

--- a/plugin/build.gradle.kts
+++ b/plugin/build.gradle.kts
@@ -7,6 +7,15 @@ plugins {
 dependencies {
     implementation(gradleApi())
     implementation(libs.plugin.kotlin)
+
+    testImplementation(gradleTestKit())
+    testImplementation(libs.test.junit.jupiter)
+    testImplementation(libs.test.kotest.assertions)
+    testRuntimeOnly(libs.test.junit.jupiter.launcher)
+}
+
+tasks.named<Test>("test") {
+    useJUnitPlatform()
 }
 
 version = "0.5.1"

--- a/plugin/src/main/kotlin/io/github/ttypic/swiftklib/gradle/SwiftKlibEntry.kt
+++ b/plugin/src/main/kotlin/io/github/ttypic/swiftklib/gradle/SwiftKlibEntry.kt
@@ -1,47 +1,21 @@
 package io.github.ttypic.swiftklib.gradle
 
+import org.gradle.api.model.ObjectFactory
 import org.gradle.api.provider.Property
 import java.io.File
 import javax.inject.Inject
 
-abstract class SwiftKlibEntry @Inject constructor(val name: String) {
+abstract class SwiftKlibEntry @Inject constructor(
+    val name: String,
+    objects: ObjectFactory,
+) {
 
-    abstract val pathProperty: Property<File>
-    abstract val packageNameProperty: Property<String>
-    abstract val minIosProperty: Property<Int>
-    abstract val minMacosProperty: Property<Int>
-    abstract val minTvosProperty: Property<Int>
-    abstract val minWatchosProperty: Property<Int>
+    val path: Property<File> = objects.property(File::class.java)
+    val packageName: Property<String> = objects.property(String::class.java)
+    val minIos: Property<Int> = objects.property(Int::class.java)
+    val minMacos: Property<Int> = objects.property(Int::class.java)
+    val minTvos: Property<Int> = objects.property(Int::class.java)
+    val minWatchos: Property<Int> = objects.property(Int::class.java)
 
-    var path: File
-        get() = pathProperty.get()
-        set(value) {
-            pathProperty.set(value)
-        }
-
-    fun packageName(name: String) = packageNameProperty.set(name)
-
-    var minIos: Int
-        get() = minIosProperty.get()
-        set(value) {
-            minIosProperty.set(value)
-        }
-
-    var minMacos: Int
-        get() = minMacosProperty.get()
-        set(value) {
-            minMacosProperty.set(value)
-        }
-
-    var minTvos: Int
-        get() = minTvosProperty.get()
-        set(value) {
-            minTvosProperty.set(value)
-        }
-
-    var minWatchos: Int
-        get() = minWatchosProperty.get()
-        set(value) {
-            minWatchosProperty.set(value)
-        }
+    fun packageName(name: String) = packageName.set(name)
 }

--- a/plugin/src/main/kotlin/io/github/ttypic/swiftklib/gradle/SwiftKlibPlugin.kt
+++ b/plugin/src/main/kotlin/io/github/ttypic/swiftklib/gradle/SwiftKlibPlugin.kt
@@ -10,6 +10,7 @@ import org.jetbrains.kotlin.gradle.tasks.CInteropProcess
 
 const val EXTENSION_NAME = "swiftklib"
 
+@Suppress("unused")
 class SwiftKlibPlugin : Plugin<Project> {
     override fun apply(target: Project) = with(target) {
         val objects: ObjectFactory = project.objects
@@ -36,12 +37,12 @@ class SwiftKlibPlugin : Plugin<Project> {
                     name,
                     target,
                     buildDir,
-                    entry.pathProperty,
-                    entry.packageNameProperty,
-                    entry.minIosProperty,
-                    entry.minMacosProperty,
-                    entry.minTvosProperty,
-                    entry.minWatchosProperty,
+                    entry.path,
+                    entry.packageName,
+                    entry.minIos,
+                    entry.minMacos,
+                    entry.minTvos,
+                    entry.minWatchos,
                 )
             }
         }

--- a/plugin/src/main/kotlin/io/github/ttypic/swiftklib/gradle/SwiftKlibPlugin.kt
+++ b/plugin/src/main/kotlin/io/github/ttypic/swiftklib/gradle/SwiftKlibPlugin.kt
@@ -28,12 +28,14 @@ class SwiftKlibPlugin : Plugin<Project> {
                 getTaskName(name, it)
             }
 
+            val buildDir = project.layout.buildDirectory.asFile.get().absolutePath
             targetToTaskName.entries.forEach { (target, taskName) ->
                 tasks.register(
                     taskName,
                     CompileSwiftTask::class.java,
                     name,
                     target,
+                    buildDir,
                     entry.pathProperty,
                     entry.packageNameProperty,
                     entry.minIosProperty,

--- a/plugin/src/main/kotlin/io/github/ttypic/swiftklib/gradle/SwiftKlibPlugin.kt
+++ b/plugin/src/main/kotlin/io/github/ttypic/swiftklib/gradle/SwiftKlibPlugin.kt
@@ -24,7 +24,7 @@ class SwiftKlibPlugin : Plugin<Project> {
         swiftKlibEntries.all { entry ->
             val name: String = entry.name
 
-            val targetToTaskName = CompileTarget.values().associateWith {
+            val targetToTaskName = CompileTarget.entries.associateWith {
                 getTaskName(name, it)
             }
 

--- a/plugin/src/main/kotlin/io/github/ttypic/swiftklib/gradle/task/CompileSwiftTask.kt
+++ b/plugin/src/main/kotlin/io/github/ttypic/swiftklib/gradle/task/CompileSwiftTask.kt
@@ -22,6 +22,7 @@ import javax.inject.Inject
 open class CompileSwiftTask @Inject constructor(
     @Input val cinteropName: String,
     @Input val compileTarget: CompileTarget,
+    @Input val buildDirectory: String,
     @InputDirectory val pathProperty: Property<File>,
     @Input val packageNameProperty: Property<String>,
     @Optional @Input val minIosProperty: Property<Int>,
@@ -33,7 +34,7 @@ open class CompileSwiftTask @Inject constructor(
     @get:Internal
     internal val targetDir: File
         get() {
-            return project.layout.buildDirectory.file("${EXTENSION_NAME}/$cinteropName/$compileTarget").get().asFile
+            return File(buildDirectory, "${EXTENSION_NAME}/$cinteropName/$compileTarget")
         }
 
     @get:OutputDirectory

--- a/plugin/src/main/kotlin/io/github/ttypic/swiftklib/gradle/task/CompileSwiftTask.kt
+++ b/plugin/src/main/kotlin/io/github/ttypic/swiftklib/gradle/task/CompileSwiftTask.kt
@@ -92,7 +92,7 @@ abstract class CompileSwiftTask @Inject constructor(
      */
     private fun createPackageSwift() {
         File(swiftBuildDir, "Package.swift")
-            .create(createPackageSwiftContents(cinteropName))
+            .writeText(createPackageSwiftContents(cinteropName))
     }
 
     private fun buildSwift(xcodeVersion: Int): SwiftBuildResult {
@@ -249,7 +249,7 @@ abstract class CompileSwiftTask @Inject constructor(
         logger.info(content)
         logger.info("---/ cinterop def /---")
 
-        defFile.create(content)
+        defFile.writeText(content)
     }
 
     private fun CompileTarget.operatingSystem(): String =
@@ -285,12 +285,6 @@ val SDKLESS_TARGETS = listOf(
     CompileTarget.tvosX64,
     CompileTarget.tvosSimulatorArm64,
 )
-
-private fun File.create(content: String) {
-    bufferedWriter().use {
-        it.write(content)
-    }
-}
 
 private fun File.md5() = BigInteger(1, MessageDigest.getInstance("MD5").digest(readBytes()))
     .toString(16)

--- a/plugin/src/main/kotlin/io/github/ttypic/swiftklib/gradle/task/CompileSwiftTask.kt
+++ b/plugin/src/main/kotlin/io/github/ttypic/swiftklib/gradle/task/CompileSwiftTask.kt
@@ -13,13 +13,14 @@ import org.gradle.api.tasks.Optional
 import org.gradle.api.tasks.OutputDirectory
 import org.gradle.api.tasks.OutputFile
 import org.gradle.api.tasks.TaskAction
+import org.gradle.process.ExecOperations
 import java.io.ByteArrayOutputStream
 import java.io.File
 import java.math.BigInteger
 import java.security.MessageDigest
 import javax.inject.Inject
 
-open class CompileSwiftTask @Inject constructor(
+abstract class CompileSwiftTask @Inject constructor(
     @Input val cinteropName: String,
     @Input val compileTarget: CompileTarget,
     @Input val buildDirectory: String,
@@ -44,6 +45,9 @@ open class CompileSwiftTask @Inject constructor(
     @get:OutputFile
     val defFile
         get() = File(targetDir, "$cinteropName.def")
+
+    @get:Inject
+    abstract val execOperations: ExecOperations
 
     @TaskAction
     fun produce() {
@@ -108,7 +112,7 @@ open class CompileSwiftTask @Inject constructor(
         logger.info("Working directory: $swiftBuildDir")
         logger.info("xcrun ${args.joinToString(" ")}")
 
-        project.exec {
+        execOperations.exec {
             it.executable = "xcrun"
             it.workingDir = swiftBuildDir
             it.args = args
@@ -163,7 +167,7 @@ open class CompileSwiftTask @Inject constructor(
     private fun readSdkPath(): String {
         val stdout = ByteArrayOutputStream()
 
-        project.exec {
+        execOperations.exec {
             it.executable = "xcrun"
             it.args = listOf(
                 "--sdk",
@@ -179,7 +183,7 @@ open class CompileSwiftTask @Inject constructor(
     private fun readXcodeMajorVersion(): Int {
         val stdout = ByteArrayOutputStream()
 
-        project.exec {
+        execOperations.exec {
             it.executable = "xcodebuild"
             it.args = listOf("-version")
             it.standardOutput = stdout
@@ -195,7 +199,7 @@ open class CompileSwiftTask @Inject constructor(
     private fun readXcodePath(): String {
         val stdout = ByteArrayOutputStream()
 
-        project.exec {
+        execOperations.exec {
             it.executable = "xcode-select"
             it.args = listOf("--print-path")
             it.standardOutput = stdout

--- a/plugin/src/main/kotlin/io/github/ttypic/swiftklib/gradle/task/CompileSwiftTask.kt
+++ b/plugin/src/main/kotlin/io/github/ttypic/swiftklib/gradle/task/CompileSwiftTask.kt
@@ -55,12 +55,14 @@ abstract class CompileSwiftTask @Inject constructor(
 
         prepareBuildDirectory()
         createPackageSwift()
-        val (libPath, headerPath) = buildSwift()
+        val xcodeMajorVersion = readXcodeMajorVersion()
+        val (libPath, headerPath) = buildSwift(xcodeMajorVersion)
 
         createDefFile(
             libPath = libPath,
             headerPath = headerPath,
             packageName = packageName,
+            xcodeVersion = xcodeMajorVersion,
         )
     }
 
@@ -68,10 +70,6 @@ abstract class CompileSwiftTask @Inject constructor(
     private val minMacos get() = minMacosProperty.getOrElse(11)
     private val minTvos get() = minTvosProperty.getOrElse(13)
     private val minWatchos get() = minWatchosProperty.getOrElse(8)
-
-    private val xcodeVersion: Int by lazy {
-        readXcodeMajorVersion()
-    }
 
     /**
      * Creates build directory or cleans up if it already exists
@@ -97,7 +95,7 @@ abstract class CompileSwiftTask @Inject constructor(
             .create(createPackageSwiftContents(cinteropName))
     }
 
-    private fun buildSwift(): SwiftBuildResult {
+    private fun buildSwift(xcodeVersion: Int): SwiftBuildResult {
         val sourceFilePathReplacements = mapOf(
             buildDir().absolutePath to pathProperty.get().absolutePath
         )
@@ -214,7 +212,7 @@ abstract class CompileSwiftTask @Inject constructor(
      * Note: adds lib-file md5 hash to library in order to automatically
      * invalidate connected cinterop task
      */
-    private fun createDefFile(libPath: File, headerPath: File, packageName: String) {
+    private fun createDefFile(libPath: File, headerPath: File, packageName: String, xcodeVersion: Int) {
         val xcodePath = readXcodePath()
 
         val linkerPlatformVersion =

--- a/plugin/src/main/kotlin/io/github/ttypic/swiftklib/gradle/task/CompileSwiftTask.kt
+++ b/plugin/src/main/kotlin/io/github/ttypic/swiftklib/gradle/task/CompileSwiftTask.kt
@@ -273,7 +273,9 @@ private data class SwiftBuildResult(
 )
 
 val SDKLESS_TARGETS = listOf(
+    CompileTarget.iosX64,
     CompileTarget.iosArm64,
+    CompileTarget.iosSimulatorArm64,
     CompileTarget.watchosArm64,
     CompileTarget.watchosX64,
     CompileTarget.watchosSimulatorArm64,

--- a/plugin/src/main/kotlin/io/github/ttypic/swiftklib/gradle/task/CompileTargetExt.kt
+++ b/plugin/src/main/kotlin/io/github/ttypic/swiftklib/gradle/task/CompileTargetExt.kt
@@ -72,3 +72,7 @@ internal fun CompileTarget.linkerMinOsVersionName() = when(this) {
     CompileTarget.macosX64 -> "macosx_version_min"
     CompileTarget.macosArm64 -> "macosx_version_min"
 }
+
+internal fun CompileTarget.asSwiftcTarget(operatingSystem: String): String {
+    return "${archPrefix()}-apple-${operatingSystem}.0${simulatorSuffix()}"
+}

--- a/plugin/src/test/kotlin/io/github/ttypic/swiftklib/gradle/CinteropModulesTest.kt
+++ b/plugin/src/test/kotlin/io/github/ttypic/swiftklib/gradle/CinteropModulesTest.kt
@@ -1,0 +1,133 @@
+package io.github.ttypic.swiftklib.gradle
+
+import io.kotest.matchers.nulls.shouldNotBeNull
+import io.kotest.matchers.shouldBe
+import org.gradle.testkit.runner.BuildResult
+import org.gradle.testkit.runner.GradleRunner
+import org.gradle.testkit.runner.TaskOutcome
+import org.intellij.lang.annotations.Language
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
+import java.io.File
+
+class CinteropModulesTest {
+    @TempDir
+    lateinit var testProjectDir: File
+    private lateinit var settingsFile: File
+    private lateinit var buildFile: File
+    private lateinit var swiftLocation: File
+    private lateinit var swiftCodeFile: File
+    private lateinit var kotlinLocation: File
+    private lateinit var kotlinCodeFile: File
+    private lateinit var gradlePropertiesFile: File
+
+    @BeforeEach
+    fun setup() {
+        settingsFile = File(testProjectDir, "settings.gradle.kts")
+        buildFile = File(testProjectDir, "build.gradle.kts")
+        swiftLocation = File(testProjectDir, "swift")
+        swiftCodeFile = File(swiftLocation, "test.swift")
+        kotlinLocation = File(testProjectDir, "src/commonMain/kotlin/test")
+        kotlinCodeFile = File(kotlinLocation, "Test.kt")
+        gradlePropertiesFile = File(testProjectDir, "gradle.properties")
+    }
+
+    @Test
+    fun `build with imported UIKit framework is successful`() {
+        testBuild(
+            swiftCode = """
+                import UIKit
+
+                @objc public class TestView: UIView {}
+            """.trimIndent(),
+            kotlinCode = """
+                import test.TestView
+
+                val view = TestView()
+            """.trimIndent(),
+        ) {
+            task(":build")
+                .shouldNotBeNull()
+                .outcome.shouldBe(TaskOutcome.SUCCESS)
+        }
+    }
+
+    private fun testBuild(
+        @Language("swift")
+        swiftCode: String,
+        @Language("kotlin")
+        kotlinCode: String = "",
+        swiftklibName: String = "test",
+        swiftklibPackage: String = "test",
+        asserter: BuildResult.() -> Unit,
+    ) {
+        gradlePropertiesFile.writeText(
+            """
+                kotlin.mpp.enableCInteropCommonization=true
+            """.trimIndent()
+        )
+        @Language("kotlin")
+        val settingsKts = """
+            pluginManagement {
+              includeBuild("..")
+            }
+
+            dependencyResolutionManagement {
+              repositories {
+                mavenCentral()
+              }
+            }
+        """.trimIndent()
+        settingsFile.writeText(settingsKts)
+
+        @Language("kotlin")
+        val buildKts = """
+            plugins {
+              embeddedKotlin("multiplatform")
+              id("io.github.ttypic.swiftklib")
+            }
+
+            kotlin {
+              compilerOptions {
+                optIn.addAll(
+                  "kotlinx.cinterop.ExperimentalForeignApi",
+                )
+              }
+
+              listOf(
+                iosX64(),
+                iosArm64(),
+                iosSimulatorArm64(),
+              ).forEach {
+                it.compilations {
+                  val main by getting {
+                    cinterops.create("$swiftklibName")
+                  }
+                }
+              }
+            }
+
+            swiftklib {
+              create("$swiftklibName") {
+                path = file("${swiftLocation.absolutePath}")
+                packageName("$swiftklibPackage")
+              }
+            }
+        """.trimIndent()
+        buildFile.writeText(buildKts)
+
+        swiftLocation.mkdirs()
+        kotlinLocation.mkdirs()
+
+        swiftCodeFile.writeText(swiftCode)
+        kotlinCodeFile.writeText(kotlinCode)
+
+        GradleRunner.create()
+            .withProjectDir(testProjectDir)
+            .withArguments("build")
+            .withPluginClasspath()
+            .build()
+            .asserter()
+    }
+}


### PR DESCRIPTION
This PR is based on #31 and should be reviewed and merged after #31.

This change makes `cinterop` support usage of clang modules in Objective-C headers.
This is required to be able to use any modern apple framework (including `UIKit`, `AVFoundation`, etc).

Basically, any Objective-C header containing `@import` directive requires modules to be enabled.

This change seems to be backwards compatible since we are generating cinterops for our own builds which are guaranteed to be clang modules.

Also, I've added `iosX64` and `iosSimulatorArm64` to list of targets which are required sdk path to be provided to `swift build`.

Finally, I've fixed all configuration cache issues.

Also, this fixes issue https://github.com/ttypic/swift-klib-plugin/issues/25