### PR TITLE
Fixed - 'swiftbuild': Invalid manifest. using sysroot for 'iPhoneSimulator' but targeting 'MacOSX'

### DIFF
--- a/plugin/src/main/kotlin/io/github/ttypic/swiftklib/gradle/task/CompileSwiftTask.kt
+++ b/plugin/src/main/kotlin/io/github/ttypic/swiftklib/gradle/task/CompileSwiftTask.kt
@@ -104,7 +104,8 @@ abstract class CompileSwiftTask @Inject constructor(
         } else {
             emptyList()
         }
-        val args = generateBuildArgs() + extraArgs
+        val sdkForXcRun = listOf("--sdk", "macosx")
+        val args = sdkForXcRun + generateBuildArgs() + extraArgs
 
         logger.info("-- Running swift build --")
         logger.info("Working directory: $swiftBuildDir")


### PR DESCRIPTION
**Fix** 
The fix is to explicitly add the` --sdk macosx` flag in the `xcrun` command. This doesn’t mean the **intended target is macOS**, but rather ensures that the correct build tools are selected for the iPhoneSimulator platform.

### Root cause
The issue occurred because the build process was targeting the `iPhoneSimulator`, but the error indicated it was incorrectly using `MacOSX`. This is because, when building and running the iOS app, certain environment variables are set by default. These variables could lead to a mismatch in the `xcrun` SDK path, resulting in the creation of a manifest error.

### How it worked while `Sync` project or first time ?
You might be curious about why syncing the project allowed it to run successfully the first time, even before the changes in the Swift file. This is because the environment variables are not set while syncing the project.


