### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,12 @@ buildscript {
 
 apply(plugin = "io.github.ttypic.swiftklib")
 ```
+Add this to the project-level gradle.properties file (if it’s not already included).
+```properties
+#Kotlin Multiplatform
+kotlin.mpp.enableCInteropCommonization=true
+
+```
 
 ## Usage
 


### PR DESCRIPTION
Enable CInteropCommonization in gradle level.

Recently, I noticed new KMP projects didn't include this CInteropCommonization property in gradle.properties by default. Without it, importing Kotlin into the iosApp module isn't possible.