### PR TITLE
[Experimental]alternative for using external dependencies implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,7 +100,8 @@ swiftklib {
 
 ### Examples
 
-More samples can be found in the [examples/](https://github.com/ttypic/swift-klib-plugin/tree/main/examples) folder.
+- More samples can be found in the [examples/](https://github.com/ttypic/swift-klib-plugin/tree/main/examples) folder.
+- Component demonstrating a multipurpose Kotlin Multiplatform and Swift Package audio player: [radioplayer-kt](https://github.com/markst/radioplayer-kt)
 
 ## License
 

--- a/plugin/src/functionalTest/kotlin/io/github/ttypic/swiftklib/gradle/SwiftPackageModulesTest.kt
+++ b/plugin/src/functionalTest/kotlin/io/github/ttypic/swiftklib/gradle/SwiftPackageModulesTest.kt
@@ -464,7 +464,7 @@ class SwiftPackageModulesTest {
             """.trimIndent())
             )
             .withConfiguration {
-                toolsVersion = "5.3"
+                toolsVersion = "100.0"
                 dependencies {
                 }
             }
@@ -474,9 +474,9 @@ class SwiftPackageModulesTest {
         val result = buildAndFail(fixture.gradleProject.rootDir, "build")
 
         // Then
-        assertThat(result).output().contains("package manifest version 5.3.0 is too old")
+        assertThat(result).output().contains("is using Swift tools version 100.0.0")
         getManifestContent(fixture) { manifest ->
-            assertTrue(manifest.contains("swift-tools-version:5.3"))
+            assertTrue(manifest.contains("swift-tools-version: 100.0"), "must contains version 100.0")
         }
     }
 

--- a/plugin/src/functionalTest/kotlin/io/github/ttypic/swiftklib/gradle/fixture/SwiftKlibTestFixture.kt
+++ b/plugin/src/functionalTest/kotlin/io/github/ttypic/swiftklib/gradle/fixture/SwiftKlibTestFixture.kt
@@ -232,14 +232,17 @@ private class TestSwiftPackageConfigurationImpl : SwiftPackageConfiguration {
 private class TestRemotePackageConfigurationImpl(private val name: String) : RemotePackageConfiguration {
 
     private var url: String? = null
+    private var packageName: String? = null
     private var versionConfig: TestVersionConfig? = null
 
-    override fun github(owner: String, repo: String) {
+    override fun github(owner: String, repo: String, packageName: String?) {
         url = "https://github.com/$owner/$repo.git"
+        this.packageName = packageName
     }
 
-    override fun url(url: String) {
+    override fun url(url: String, packageName: String?) {
         this.url = url
+        this.packageName = name
     }
 
     override fun exactVersion(version: String) {

--- a/plugin/src/functionalTest/kotlin/io/github/ttypic/swiftklib/gradle/fixture/SwiftKlibTestFixture.kt
+++ b/plugin/src/functionalTest/kotlin/io/github/ttypic/swiftklib/gradle/fixture/SwiftKlibTestFixture.kt
@@ -226,8 +226,8 @@ private class TestSwiftPackageConfigurationImpl : SwiftPackageConfiguration {
         remote(listOf(name), configuration)
     }
 
-    override fun remote(name: List<String>, configuration: RemotePackageConfiguration.() -> Unit) {
-        val config = TestRemotePackageConfigurationImpl(name)
+    override fun remote(names: List<String>, configuration: RemotePackageConfiguration.() -> Unit) {
+        val config = TestRemotePackageConfigurationImpl(names)
         config.configuration()
         dependencies.add(config.build())
     }

--- a/plugin/src/functionalTest/kotlin/io/github/ttypic/swiftklib/gradle/fixture/SwiftKlibTestFixture.kt
+++ b/plugin/src/functionalTest/kotlin/io/github/ttypic/swiftklib/gradle/fixture/SwiftKlibTestFixture.kt
@@ -140,6 +140,9 @@ abstract class SwiftKlibTestFixture private constructor(
             if (entry._minWatchos.hasValue()) {
                 appendLine("        minWatchos = \"${entry.minWatchos}\"")
             }
+            if (!entry._toolsVersions.isNullOrEmpty()) {
+                appendLine("        toolsVersion = \"${entry.toolsVersion}\"")
+            }
 
             if (entry.dependencies.isNotEmpty()) {
                 appendLine("        dependencies {")
@@ -194,12 +197,15 @@ private class TestSwiftKlibEntryImpl : SwiftKlibEntry {
     val _minMacos = notNull<String>()
     val _minTvos = notNull<String>()
     val _minWatchos = notNull<String>()
+    val _toolsVersions: String?
+        get() = toolsVersion
 
     override var path: File by _path
     override var minIos: String by _minIos
     override var minMacos: String by _minMacos
     override var minTvos: String by _minTvos
     override var minWatchos: String by _minWatchos
+    override var toolsVersion: String? = null
 
     val dependencies = mutableListOf<TestDependencyConfig>()
 

--- a/plugin/src/functionalTest/kotlin/io/github/ttypic/swiftklib/gradle/fixture/SwiftKlibTestFixture.kt
+++ b/plugin/src/functionalTest/kotlin/io/github/ttypic/swiftklib/gradle/fixture/SwiftKlibTestFixture.kt
@@ -223,13 +223,17 @@ private class TestSwiftPackageConfigurationImpl : SwiftPackageConfiguration {
     }
 
     override fun remote(name: String, configuration: RemotePackageConfiguration.() -> Unit) {
+        remote(listOf(name), configuration)
+    }
+
+    override fun remote(name: List<String>, configuration: RemotePackageConfiguration.() -> Unit) {
         val config = TestRemotePackageConfigurationImpl(name)
         config.configuration()
         dependencies.add(config.build())
     }
 }
 
-private class TestRemotePackageConfigurationImpl(private val name: String) :
+private class TestRemotePackageConfigurationImpl(private val name: List<String>) :
     RemotePackageConfiguration {
 
     private var url: String? = null
@@ -280,13 +284,17 @@ private sealed interface TestDependencyConfig {
     }
 
     data class Remote(
-        val name: String,
+        val name: List<String>,
         val url: String?,
         val version: TestVersionConfig?,
         val packageName: String?
     ) : TestDependencyConfig {
         override fun toConfigString() = buildString {
-            append("remote(\"$name\") {\n")
+            if (name.size == 1) {
+                append("remote(\"${name.first()}\") {\n")
+            } else {
+                append("remote(listOf(\"${name.joinToString("\",\"")}\")) {\n")
+            }
             if (url != null) {
                 if (packageName != null) {
                     append("                url(\"$url\", \"$packageName\")\n")

--- a/plugin/src/functionalTest/kotlin/io/github/ttypic/swiftklib/gradle/fixture/SwiftKlibTestFixture.kt
+++ b/plugin/src/functionalTest/kotlin/io/github/ttypic/swiftklib/gradle/fixture/SwiftKlibTestFixture.kt
@@ -140,7 +140,7 @@ abstract class SwiftKlibTestFixture private constructor(
             if (entry._minWatchos.hasValue()) {
                 appendLine("        minWatchos = \"${entry.minWatchos}\"")
             }
-            if (!entry._toolsVersions.isNullOrEmpty()) {
+            if (entry._toolsVersions.hasValue()) {
                 appendLine("        toolsVersion = \"${entry.toolsVersion}\"")
             }
 
@@ -197,15 +197,14 @@ private class TestSwiftKlibEntryImpl : SwiftKlibEntry {
     val _minMacos = notNull<String>()
     val _minTvos = notNull<String>()
     val _minWatchos = notNull<String>()
-    val _toolsVersions: String?
-        get() = toolsVersion
+    val _toolsVersions = notNull<String>()
 
     override var path: File by _path
     override var minIos: String by _minIos
     override var minMacos: String by _minMacos
     override var minTvos: String by _minTvos
     override var minWatchos: String by _minWatchos
-    override var toolsVersion: String? = null
+    override var toolsVersion: String by _toolsVersions
 
     val dependencies = mutableListOf<TestDependencyConfig>()
 

--- a/plugin/src/main/kotlin/io/github/ttypic/swiftklib/gradle/RemotePackageBuilder.kt
+++ b/plugin/src/main/kotlin/io/github/ttypic/swiftklib/gradle/RemotePackageBuilder.kt
@@ -8,7 +8,7 @@ import javax.inject.Inject
 @ExperimentalSwiftklibApi
 class RemotePackageBuilder @Inject constructor(
     private val objects: ObjectFactory,
-    private val name: String
+    private val name: List<String>
 ) {
     private val urlProperty: Property<String> = objects.property(String::class.java)
     private var dependency: SwiftPackageDependency.Remote? = null

--- a/plugin/src/main/kotlin/io/github/ttypic/swiftklib/gradle/SwiftKlibEntryImpl.kt
+++ b/plugin/src/main/kotlin/io/github/ttypic/swiftklib/gradle/SwiftKlibEntryImpl.kt
@@ -16,6 +16,7 @@ internal abstract class SwiftKlibEntryImpl @Inject constructor(
 ) : SwiftKlibEntry {
     val _path: Property<File> = objects.property(File::class.java)
     val _packageName: Property<String> = objects.property(String::class.java)
+    val _toolsVersion: Property<String?> = objects.property(String::class.java)
     val _minIos: Property<String> = objects.property(String::class.java).convention("12.0")
     val _minMacos: Property<String> = objects.property(String::class.java).convention("10.13")
     val _minTvos: Property<String> = objects.property(String::class.java).convention("12.0")
@@ -25,6 +26,7 @@ internal abstract class SwiftKlibEntryImpl @Inject constructor(
     override var minMacos: String by _minMacos.bind()
     override var minTvos: String by _minTvos.bind()
     override var minWatchos: String by _minWatchos.bind()
+    override var toolsVersion: String? by _toolsVersion.bind()
 
     internal val dependencyHandler = SwiftPackageConfigurationImpl(objects)
 

--- a/plugin/src/main/kotlin/io/github/ttypic/swiftklib/gradle/SwiftKlibEntryImpl.kt
+++ b/plugin/src/main/kotlin/io/github/ttypic/swiftklib/gradle/SwiftKlibEntryImpl.kt
@@ -16,16 +16,15 @@ internal abstract class SwiftKlibEntryImpl @Inject constructor(
 ) : SwiftKlibEntry {
     val _path: Property<File> = objects.property(File::class.java)
     val _packageName: Property<String> = objects.property(String::class.java)
-    val _minIos: Property<Int> = objects.property(Int::class.java).convention(13)
-    val _minMacos: Property<Int> = objects.property(Int::class.java).convention(11)
-    val _minTvos: Property<Int> = objects.property(Int::class.java).convention(13)
-    val _minWatchos: Property<Int> = objects.property(Int::class.java).convention(8)
-
+    val _minIos: Property<String> = objects.property(String::class.java).convention("12.0")
+    val _minMacos: Property<String> = objects.property(String::class.java).convention("10.13")
+    val _minTvos: Property<String> = objects.property(String::class.java).convention("12.0")
+    val _minWatchos: Property<String> = objects.property(String::class.java).convention("4.0")
     override var path: File by _path.bind()
-    override var minIos: Int by _minIos.bind()
-    override var minMacos: Int by _minMacos.bind()
-    override var minTvos: Int by _minTvos.bind()
-    override var minWatchos: Int by _minWatchos.bind()
+    override var minIos: String by _minIos.bind()
+    override var minMacos: String by _minMacos.bind()
+    override var minTvos: String by _minTvos.bind()
+    override var minWatchos: String by _minWatchos.bind()
 
     internal val dependencyHandler = SwiftPackageConfigurationImpl(objects)
 

--- a/plugin/src/main/kotlin/io/github/ttypic/swiftklib/gradle/SwiftKlibEntryImpl.kt
+++ b/plugin/src/main/kotlin/io/github/ttypic/swiftklib/gradle/SwiftKlibEntryImpl.kt
@@ -16,7 +16,7 @@ internal abstract class SwiftKlibEntryImpl @Inject constructor(
 ) : SwiftKlibEntry {
     val _path: Property<File> = objects.property(File::class.java)
     val _packageName: Property<String> = objects.property(String::class.java)
-    val _toolsVersion: Property<String?> = objects.property(String::class.java)
+    val _toolsVersion: Property<String> = objects.property(String::class.java).convention("5.6")
     val _minIos: Property<String> = objects.property(String::class.java).convention("12.0")
     val _minMacos: Property<String> = objects.property(String::class.java).convention("10.13")
     val _minTvos: Property<String> = objects.property(String::class.java).convention("12.0")
@@ -26,7 +26,7 @@ internal abstract class SwiftKlibEntryImpl @Inject constructor(
     override var minMacos: String by _minMacos.bind()
     override var minTvos: String by _minTvos.bind()
     override var minWatchos: String by _minWatchos.bind()
-    override var toolsVersion: String? by _toolsVersion.bind()
+    override var toolsVersion: String by _toolsVersion.bind()
 
     internal val dependencyHandler = SwiftPackageConfigurationImpl(objects)
 

--- a/plugin/src/main/kotlin/io/github/ttypic/swiftklib/gradle/SwiftKlibEntryImpl.kt
+++ b/plugin/src/main/kotlin/io/github/ttypic/swiftklib/gradle/SwiftKlibEntryImpl.kt
@@ -16,7 +16,7 @@ internal abstract class SwiftKlibEntryImpl @Inject constructor(
 ) : SwiftKlibEntry {
     val _path: Property<File> = objects.property(File::class.java)
     val _packageName: Property<String> = objects.property(String::class.java)
-    val _toolsVersion: Property<String> = objects.property(String::class.java).convention("5.6")
+    val _toolsVersion: Property<String> = objects.property(String::class.java).convention("5.9")
     val _minIos: Property<String> = objects.property(String::class.java).convention("12.0")
     val _minMacos: Property<String> = objects.property(String::class.java).convention("10.13")
     val _minTvos: Property<String> = objects.property(String::class.java).convention("12.0")

--- a/plugin/src/main/kotlin/io/github/ttypic/swiftklib/gradle/SwiftKlibPlugin.kt
+++ b/plugin/src/main/kotlin/io/github/ttypic/swiftklib/gradle/SwiftKlibPlugin.kt
@@ -59,6 +59,7 @@ class SwiftKlibPlugin : Plugin<Project> {
                     entry._minMacos,
                     entry._minTvos,
                     entry._minWatchos,
+                    entry._toolsVersion
                 ).configure {
                     it.dependenciesProperty = entry.dependencyHandler.dependencies
                 }

--- a/plugin/src/main/kotlin/io/github/ttypic/swiftklib/gradle/SwiftPackageDependency.kt
+++ b/plugin/src/main/kotlin/io/github/ttypic/swiftklib/gradle/SwiftPackageDependency.kt
@@ -18,7 +18,7 @@ internal sealed interface SwiftPackageDependency : Serializable {
         @Input @get:Optional override val packageName: String? = null,
     ) : SwiftPackageDependency {
         init {
-            require(name.isNotEmpty() && !name.contains("")) { "Package name cannot be blank" }
+            require(name.isNotEmpty() && name.none { it.isBlank() }) { "Package name cannot be blank" }
             require(path.exists()) { "Package path must exist: $path" }
         }
     }
@@ -34,7 +34,7 @@ internal sealed interface SwiftPackageDependency : Serializable {
             @Input @get:Optional override val packageName: String? = null
         ) : Remote {
             init {
-                require(name.isNotEmpty() && !name.contains("")) { "Package name cannot be blank" }
+                require(name.isNotEmpty() && name.none { it.isBlank() }) { "Package name cannot be blank" }
                 require(url.isNotBlank()) { "URL cannot be blank" }
                 require(version.isNotBlank()) { "Version cannot be blank" }
             }
@@ -49,7 +49,7 @@ internal sealed interface SwiftPackageDependency : Serializable {
             @Input @get:Optional override val packageName: String? = null
         ) : Remote {
             init {
-                require(name.isNotEmpty() && !name.contains("")) { "Package name cannot be blank" }
+                require(name.isNotEmpty() && name.none { it.isBlank() }) { "Package name cannot be blank" }
                 require(url.isNotBlank()) { "URL cannot be blank" }
                 require(from.isNotBlank()) { "From version cannot be blank" }
                 require(to.isNotBlank()) { "To version cannot be blank" }
@@ -63,7 +63,7 @@ internal sealed interface SwiftPackageDependency : Serializable {
             @Input @get:Optional override val packageName: String? = null
         ) : Remote {
             init {
-                require(name.isNotEmpty() && !name.contains("")) { "Package name cannot be blank" }
+                require(name.isNotEmpty() && name.none { it.isBlank() }) { "Package name cannot be blank" }
                 require(url.isNotBlank()) { "URL cannot be blank" }
                 require(branchName.isNotBlank()) { "Branch name cannot be blank" }
             }
@@ -76,7 +76,7 @@ internal sealed interface SwiftPackageDependency : Serializable {
             @Input @get:Optional override val packageName: String? = null
         ) : Remote {
             init {
-                require(name.isNotEmpty() && !name.contains("")) { "Package name cannot be blank" }
+                require(name.isNotEmpty() && name.none { it.isBlank() }) { "Package name cannot be blank" }
                 require(url.isNotBlank()) { "URL cannot be blank" }
                 require(version.isNotBlank()) { "Version cannot be blank" }
             }

--- a/plugin/src/main/kotlin/io/github/ttypic/swiftklib/gradle/SwiftPackageDependency.kt
+++ b/plugin/src/main/kotlin/io/github/ttypic/swiftklib/gradle/SwiftPackageDependency.kt
@@ -2,16 +2,20 @@ package io.github.ttypic.swiftklib.gradle
 
 import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.InputDirectory
+import org.gradle.api.tasks.Optional
 import java.io.File
 import java.io.Serializable
 
 internal sealed interface SwiftPackageDependency : Serializable {
     @get:Input
     val name: String
+    @get:Input @get:Optional
+    val packageName: String?
 
     data class Local(
         @Input override val name: String,
-        @InputDirectory val path: File
+        @InputDirectory val path: File,
+        @Input @get:Optional override val packageName: String? = null,
     ) : SwiftPackageDependency {
         init {
             require(name.isNotBlank()) { "Package name cannot be blank" }
@@ -26,7 +30,8 @@ internal sealed interface SwiftPackageDependency : Serializable {
         data class ExactVersion(
             @Input override val name: String,
             @Input override val url: String,
-            @Input val version: String
+            @Input val version: String,
+            @Input @get:Optional override val packageName: String? = null
         ) : Remote {
             init {
                 require(name.isNotBlank()) { "Package name cannot be blank" }
@@ -40,7 +45,8 @@ internal sealed interface SwiftPackageDependency : Serializable {
             @Input override val url: String,
             @Input val from: String,
             @Input val to: String,
-            @Input val inclusive: Boolean = true
+            @Input val inclusive: Boolean = true,
+            @Input @get:Optional override val packageName: String? = null
         ) : Remote {
             init {
                 require(name.isNotBlank()) { "Package name cannot be blank" }
@@ -53,7 +59,8 @@ internal sealed interface SwiftPackageDependency : Serializable {
         data class Branch(
             @Input override val name: String,
             @Input override val url: String,
-            @Input val branchName: String
+            @Input val branchName: String,
+            @Input @get:Optional override val packageName: String? = null
         ) : Remote {
             init {
                 require(name.isNotBlank()) { "Package name cannot be blank" }
@@ -65,7 +72,8 @@ internal sealed interface SwiftPackageDependency : Serializable {
         data class FromVersion(
             @Input override val name: String,
             @Input override val url: String,
-            @Input val version: String
+            @Input val version: String,
+            @Input @get:Optional override val packageName: String? = null
         ) : Remote {
             init {
                 require(name.isNotBlank()) { "Package name cannot be blank" }

--- a/plugin/src/main/kotlin/io/github/ttypic/swiftklib/gradle/SwiftPackageDependency.kt
+++ b/plugin/src/main/kotlin/io/github/ttypic/swiftklib/gradle/SwiftPackageDependency.kt
@@ -18,7 +18,7 @@ internal sealed interface SwiftPackageDependency : Serializable {
         @Input @get:Optional override val packageName: String? = null,
     ) : SwiftPackageDependency {
         init {
-            require(name.isNotEmpty()) { "Package name cannot be blank" }
+            require(name.isNotEmpty() && name.indexOfFirst { it.isBlank() } == -1) { "Package name cannot be blank" }
             require(path.exists()) { "Package path must exist: $path" }
         }
     }
@@ -34,7 +34,7 @@ internal sealed interface SwiftPackageDependency : Serializable {
             @Input @get:Optional override val packageName: String? = null
         ) : Remote {
             init {
-                require(name.isNotEmpty()) { "Package name cannot be blank" }
+                require(name.isNotEmpty() && name.indexOfFirst { it.isBlank() } == -1) { "Package name cannot be blank" }
                 require(url.isNotBlank()) { "URL cannot be blank" }
                 require(version.isNotBlank()) { "Version cannot be blank" }
             }
@@ -49,7 +49,7 @@ internal sealed interface SwiftPackageDependency : Serializable {
             @Input @get:Optional override val packageName: String? = null
         ) : Remote {
             init {
-                require(name.isNotEmpty()) { "Package name cannot be blank" }
+                require(name.isNotEmpty() && name.indexOfFirst { it.isBlank() } == -1) { "Package name cannot be blank" }
                 require(url.isNotBlank()) { "URL cannot be blank" }
                 require(from.isNotBlank()) { "From version cannot be blank" }
                 require(to.isNotBlank()) { "To version cannot be blank" }
@@ -63,7 +63,7 @@ internal sealed interface SwiftPackageDependency : Serializable {
             @Input @get:Optional override val packageName: String? = null
         ) : Remote {
             init {
-                require(name.isNotEmpty()) { "Package name cannot be blank" }
+                require(name.isNotEmpty() && name.indexOfFirst { it.isBlank() } == -1) { "Package name cannot be blank" }
                 require(url.isNotBlank()) { "URL cannot be blank" }
                 require(branchName.isNotBlank()) { "Branch name cannot be blank" }
             }
@@ -76,7 +76,7 @@ internal sealed interface SwiftPackageDependency : Serializable {
             @Input @get:Optional override val packageName: String? = null
         ) : Remote {
             init {
-                require(name.isNotEmpty()) { "Package name cannot be blank" }
+                require(name.isNotEmpty() && name.indexOfFirst { it.isBlank() } == -1) { "Package name cannot be blank" }
                 require(url.isNotBlank()) { "URL cannot be blank" }
                 require(version.isNotBlank()) { "Version cannot be blank" }
             }

--- a/plugin/src/main/kotlin/io/github/ttypic/swiftklib/gradle/SwiftPackageDependency.kt
+++ b/plugin/src/main/kotlin/io/github/ttypic/swiftklib/gradle/SwiftPackageDependency.kt
@@ -8,17 +8,17 @@ import java.io.Serializable
 
 internal sealed interface SwiftPackageDependency : Serializable {
     @get:Input
-    val name: String
+    val name: List<String>
     @get:Input @get:Optional
     val packageName: String?
 
     data class Local(
-        @Input override val name: String,
+        @Input override val name: List<String>,
         @InputDirectory val path: File,
         @Input @get:Optional override val packageName: String? = null,
     ) : SwiftPackageDependency {
         init {
-            require(name.isNotBlank()) { "Package name cannot be blank" }
+            require(name.isNotEmpty()) { "Package name cannot be blank" }
             require(path.exists()) { "Package path must exist: $path" }
         }
     }
@@ -28,20 +28,20 @@ internal sealed interface SwiftPackageDependency : Serializable {
         val url: String
 
         data class ExactVersion(
-            @Input override val name: String,
+            @Input override val name: List<String>,
             @Input override val url: String,
             @Input val version: String,
             @Input @get:Optional override val packageName: String? = null
         ) : Remote {
             init {
-                require(name.isNotBlank()) { "Package name cannot be blank" }
+                require(name.isNotEmpty()) { "Package name cannot be blank" }
                 require(url.isNotBlank()) { "URL cannot be blank" }
                 require(version.isNotBlank()) { "Version cannot be blank" }
             }
         }
 
         data class VersionRange(
-            @Input override val name: String,
+            @Input override val name: List<String>,
             @Input override val url: String,
             @Input val from: String,
             @Input val to: String,
@@ -49,7 +49,7 @@ internal sealed interface SwiftPackageDependency : Serializable {
             @Input @get:Optional override val packageName: String? = null
         ) : Remote {
             init {
-                require(name.isNotBlank()) { "Package name cannot be blank" }
+                require(name.isNotEmpty()) { "Package name cannot be blank" }
                 require(url.isNotBlank()) { "URL cannot be blank" }
                 require(from.isNotBlank()) { "From version cannot be blank" }
                 require(to.isNotBlank()) { "To version cannot be blank" }
@@ -57,26 +57,26 @@ internal sealed interface SwiftPackageDependency : Serializable {
         }
 
         data class Branch(
-            @Input override val name: String,
+            @Input override val name: List<String>,
             @Input override val url: String,
             @Input val branchName: String,
             @Input @get:Optional override val packageName: String? = null
         ) : Remote {
             init {
-                require(name.isNotBlank()) { "Package name cannot be blank" }
+                require(name.isNotEmpty()) { "Package name cannot be blank" }
                 require(url.isNotBlank()) { "URL cannot be blank" }
                 require(branchName.isNotBlank()) { "Branch name cannot be blank" }
             }
         }
 
         data class FromVersion(
-            @Input override val name: String,
+            @Input override val name: List<String>,
             @Input override val url: String,
             @Input val version: String,
             @Input @get:Optional override val packageName: String? = null
         ) : Remote {
             init {
-                require(name.isNotBlank()) { "Package name cannot be blank" }
+                require(name.isNotEmpty()) { "Package name cannot be blank" }
                 require(url.isNotBlank()) { "URL cannot be blank" }
                 require(version.isNotBlank()) { "Version cannot be blank" }
             }

--- a/plugin/src/main/kotlin/io/github/ttypic/swiftklib/gradle/SwiftPackageDependency.kt
+++ b/plugin/src/main/kotlin/io/github/ttypic/swiftklib/gradle/SwiftPackageDependency.kt
@@ -18,7 +18,7 @@ internal sealed interface SwiftPackageDependency : Serializable {
         @Input @get:Optional override val packageName: String? = null,
     ) : SwiftPackageDependency {
         init {
-            require(name.isNotEmpty() && name.indexOfFirst { it.isBlank() } == -1) { "Package name cannot be blank" }
+            require(name.isNotEmpty() && !name.contains("")) { "Package name cannot be blank" }
             require(path.exists()) { "Package path must exist: $path" }
         }
     }
@@ -34,7 +34,7 @@ internal sealed interface SwiftPackageDependency : Serializable {
             @Input @get:Optional override val packageName: String? = null
         ) : Remote {
             init {
-                require(name.isNotEmpty() && name.indexOfFirst { it.isBlank() } == -1) { "Package name cannot be blank" }
+                require(name.isNotEmpty() && !name.contains("")) { "Package name cannot be blank" }
                 require(url.isNotBlank()) { "URL cannot be blank" }
                 require(version.isNotBlank()) { "Version cannot be blank" }
             }
@@ -49,7 +49,7 @@ internal sealed interface SwiftPackageDependency : Serializable {
             @Input @get:Optional override val packageName: String? = null
         ) : Remote {
             init {
-                require(name.isNotEmpty() && name.indexOfFirst { it.isBlank() } == -1) { "Package name cannot be blank" }
+                require(name.isNotEmpty() && !name.contains("")) { "Package name cannot be blank" }
                 require(url.isNotBlank()) { "URL cannot be blank" }
                 require(from.isNotBlank()) { "From version cannot be blank" }
                 require(to.isNotBlank()) { "To version cannot be blank" }
@@ -63,7 +63,7 @@ internal sealed interface SwiftPackageDependency : Serializable {
             @Input @get:Optional override val packageName: String? = null
         ) : Remote {
             init {
-                require(name.isNotEmpty() && name.indexOfFirst { it.isBlank() } == -1) { "Package name cannot be blank" }
+                require(name.isNotEmpty() && !name.contains("")) { "Package name cannot be blank" }
                 require(url.isNotBlank()) { "URL cannot be blank" }
                 require(branchName.isNotBlank()) { "Branch name cannot be blank" }
             }
@@ -76,7 +76,7 @@ internal sealed interface SwiftPackageDependency : Serializable {
             @Input @get:Optional override val packageName: String? = null
         ) : Remote {
             init {
-                require(name.isNotEmpty() && name.indexOfFirst { it.isBlank() } == -1) { "Package name cannot be blank" }
+                require(name.isNotEmpty() && !name.contains("")) { "Package name cannot be blank" }
                 require(url.isNotBlank()) { "URL cannot be blank" }
                 require(version.isNotBlank()) { "Version cannot be blank" }
             }

--- a/plugin/src/main/kotlin/io/github/ttypic/swiftklib/gradle/api/ExperimentalSwiftklibApi.kt
+++ b/plugin/src/main/kotlin/io/github/ttypic/swiftklib/gradle/api/ExperimentalSwiftklibApi.kt
@@ -1,6 +1,9 @@
 package io.github.ttypic.swiftklib.gradle.api
 
-@RequiresOptIn(message = "This API is experimental. It may be changed in the future without notice.")
+@RequiresOptIn(
+    message = "This API is experimental. It may be changed in the future without notice.",
+    level = RequiresOptIn.Level.WARNING
+)
 @Retention(AnnotationRetention.BINARY)
 @Target(AnnotationTarget.CLASS, AnnotationTarget.FUNCTION, AnnotationTarget.PROPERTY)
 annotation class ExperimentalSwiftklibApi {

--- a/plugin/src/main/kotlin/io/github/ttypic/swiftklib/gradle/api/RemotePackageConfiguration.kt
+++ b/plugin/src/main/kotlin/io/github/ttypic/swiftklib/gradle/api/RemotePackageConfiguration.kt
@@ -4,13 +4,15 @@ package io.github.ttypic.swiftklib.gradle.api
 interface RemotePackageConfiguration {
     /**
      * Sets GitHub repository as the package source.
+     * Specifies the main package name in case of multi target package (ex: Firebase)
      */
-    fun github(owner: String, repo: String)
+    fun github(owner: String, repo: String, packageName: String? = null)
 
     /**
      * Sets custom URL as the package source.
+     * Specifies the main package name in case of multi target package (ex: Firebase)
      */
-    fun url(url: String)
+    fun url(url: String, packageName: String? = null)
 
     /**
      * Specifies exact version of the package.

--- a/plugin/src/main/kotlin/io/github/ttypic/swiftklib/gradle/api/SwiftKlibEntry.kt
+++ b/plugin/src/main/kotlin/io/github/ttypic/swiftklib/gradle/api/SwiftKlibEntry.kt
@@ -9,7 +9,7 @@ interface SwiftKlibEntry {
     var minMacos: String
     var minTvos: String
     var minWatchos: String
-    var toolsVersion: String?
+    var toolsVersion: String
 
     fun packageName(name: String)
 

--- a/plugin/src/main/kotlin/io/github/ttypic/swiftklib/gradle/api/SwiftKlibEntry.kt
+++ b/plugin/src/main/kotlin/io/github/ttypic/swiftklib/gradle/api/SwiftKlibEntry.kt
@@ -5,10 +5,10 @@ import java.io.File
 interface SwiftKlibEntry {
     var path: File
 
-    var minIos: Int
-    var minMacos: Int
-    var minTvos: Int
-    var minWatchos: Int
+    var minIos: String
+    var minMacos: String
+    var minTvos: String
+    var minWatchos: String
 
     fun packageName(name: String)
 

--- a/plugin/src/main/kotlin/io/github/ttypic/swiftklib/gradle/api/SwiftKlibEntry.kt
+++ b/plugin/src/main/kotlin/io/github/ttypic/swiftklib/gradle/api/SwiftKlibEntry.kt
@@ -9,6 +9,7 @@ interface SwiftKlibEntry {
     var minMacos: String
     var minTvos: String
     var minWatchos: String
+    var toolsVersion: String?
 
     fun packageName(name: String)
 

--- a/plugin/src/main/kotlin/io/github/ttypic/swiftklib/gradle/api/SwiftPackageConfiguration.kt
+++ b/plugin/src/main/kotlin/io/github/ttypic/swiftklib/gradle/api/SwiftPackageConfiguration.kt
@@ -15,5 +15,12 @@ interface SwiftPackageConfiguration {
      * @param configuration Configuration block for the remote package
      */
     fun remote(name: String, configuration: RemotePackageConfiguration.() -> Unit)
+
+    /**
+     * Configures a remote package dependency.
+     * @param name a list of product to add
+     * @param configuration Configuration block for the remote package
+     */
+    fun remote(name: List<String>, configuration: RemotePackageConfiguration.() -> Unit)
 }
 

--- a/plugin/src/main/kotlin/io/github/ttypic/swiftklib/gradle/api/SwiftPackageConfiguration.kt
+++ b/plugin/src/main/kotlin/io/github/ttypic/swiftklib/gradle/api/SwiftPackageConfiguration.kt
@@ -11,16 +11,16 @@ interface SwiftPackageConfiguration {
 
     /**
      * Configures a remote package dependency.
-     * @param name Package name
+     * @param name the product's name to add
      * @param configuration Configuration block for the remote package
      */
     fun remote(name: String, configuration: RemotePackageConfiguration.() -> Unit)
 
     /**
      * Configures a remote package dependency.
-     * @param name a list of product to add
+     * @param names a list of product's name to add
      * @param configuration Configuration block for the remote package
      */
-    fun remote(name: List<String>, configuration: RemotePackageConfiguration.() -> Unit)
+    fun remote(names: List<String>, configuration: RemotePackageConfiguration.() -> Unit)
 }
 

--- a/plugin/src/main/kotlin/io/github/ttypic/swiftklib/gradle/internal/RemotePackageConfigurationImpl.kt
+++ b/plugin/src/main/kotlin/io/github/ttypic/swiftklib/gradle/internal/RemotePackageConfigurationImpl.kt
@@ -10,24 +10,28 @@ internal class RemotePackageConfigurationImpl @Inject constructor(
     private val name: String
 ) : RemotePackageConfiguration {
     private val urlProperty = objects.property(String::class.java)
+    private val packageName = objects.property(String::class.java)
     private var dependency: SwiftPackageDependency.Remote? = null
 
-    override fun github(owner: String, repo: String) {
+    override fun github(owner: String, repo: String, packageName: String?) {
         require(owner.isNotBlank()) { "Owner cannot be blank" }
         require(repo.isNotBlank()) { "Repo cannot be blank" }
         urlProperty.set("https://github.com/$owner/$repo.git")
+        this.packageName.set(packageName)
     }
 
-    override fun url(url: String) {
+    override fun url(url: String, packageName: String?) {
         require(url.isNotBlank()) { "URL cannot be blank" }
         urlProperty.set(url)
+        this.packageName.set(packageName)
     }
 
     override fun exactVersion(version: String) {
         dependency = SwiftPackageDependency.Remote.ExactVersion(
             name = name,
             url = requireUrl(),
-            version = version
+            version = version,
+            packageName = packageName.orNull
         )
     }
 
@@ -37,7 +41,8 @@ internal class RemotePackageConfigurationImpl @Inject constructor(
             url = requireUrl(),
             from = from,
             to = to,
-            inclusive = inclusive
+            inclusive = inclusive,
+            packageName = packageName.orNull
         )
     }
 
@@ -45,7 +50,8 @@ internal class RemotePackageConfigurationImpl @Inject constructor(
         dependency = SwiftPackageDependency.Remote.Branch(
             name = name,
             url = requireUrl(),
-            branchName = branchName
+            branchName = branchName,
+            packageName = packageName.orNull
         )
     }
 
@@ -53,7 +59,8 @@ internal class RemotePackageConfigurationImpl @Inject constructor(
         dependency = SwiftPackageDependency.Remote.FromVersion(
             name = name,
             url = requireUrl(),
-            version = version
+            version = version,
+            packageName = packageName.orNull
         )
     }
 

--- a/plugin/src/main/kotlin/io/github/ttypic/swiftklib/gradle/internal/RemotePackageConfigurationImpl.kt
+++ b/plugin/src/main/kotlin/io/github/ttypic/swiftklib/gradle/internal/RemotePackageConfigurationImpl.kt
@@ -7,7 +7,7 @@ import javax.inject.Inject
 
 internal class RemotePackageConfigurationImpl @Inject constructor(
     private val objects: ObjectFactory,
-    private val name: String
+    private val name: List<String>
 ) : RemotePackageConfiguration {
     private val urlProperty = objects.property(String::class.java)
     private val packageName = objects.property(String::class.java)

--- a/plugin/src/main/kotlin/io/github/ttypic/swiftklib/gradle/internal/SwiftPackageConfigurationImpl.kt
+++ b/plugin/src/main/kotlin/io/github/ttypic/swiftklib/gradle/internal/SwiftPackageConfigurationImpl.kt
@@ -20,15 +20,12 @@ internal class SwiftPackageConfigurationImpl @Inject constructor(
     @ExperimentalSwiftklibApi
     override fun local(name: String, path: java.io.File) {
         val currentDeps = _dependencies.get().toMutableList()
-        currentDeps.add(SwiftPackageDependency.Local(name, path))
+        currentDeps.add(SwiftPackageDependency.Local(listOf(name), path))
         _dependencies.set(currentDeps)
     }
 
     @ExperimentalSwiftklibApi
-    override fun remote(
-        name: String,
-        configuration: RemotePackageConfiguration.() -> Unit
-    ) {
+    override fun remote(name: List<String>, configuration: RemotePackageConfiguration.() -> Unit) {
         val builder = RemotePackageConfigurationImpl(objects, name)
         builder.apply(configuration)
 
@@ -38,5 +35,13 @@ internal class SwiftPackageConfigurationImpl @Inject constructor(
         val currentDeps = _dependencies.get().toMutableList()
         currentDeps.add(dependency)
         _dependencies.set(currentDeps)
+    }
+
+    @ExperimentalSwiftklibApi
+    override fun remote(
+        name: String,
+        configuration: RemotePackageConfiguration.() -> Unit
+    ) {
+        remote(listOf(name), configuration)
     }
 }

--- a/plugin/src/main/kotlin/io/github/ttypic/swiftklib/gradle/internal/SwiftPackageConfigurationImpl.kt
+++ b/plugin/src/main/kotlin/io/github/ttypic/swiftklib/gradle/internal/SwiftPackageConfigurationImpl.kt
@@ -25,7 +25,10 @@ internal class SwiftPackageConfigurationImpl @Inject constructor(
     }
 
     @ExperimentalSwiftklibApi
-    override fun remote(name: List<String>, configuration: RemotePackageConfiguration.() -> Unit) {
+    override fun remote(
+        name: List<String>,
+        configuration: RemotePackageConfiguration.() -> Unit
+    ) {
         val builder = RemotePackageConfigurationImpl(objects, name)
         builder.apply(configuration)
 
@@ -42,6 +45,14 @@ internal class SwiftPackageConfigurationImpl @Inject constructor(
         name: String,
         configuration: RemotePackageConfiguration.() -> Unit
     ) {
-        remote(listOf(name), configuration)
+        val builder = RemotePackageConfigurationImpl(objects, listOf(name))
+        builder.apply(configuration)
+
+        val dependency = builder.build()
+            ?: throw IllegalStateException("No version specification provided for remote package $name")
+
+        val currentDeps = _dependencies.get().toMutableList()
+        currentDeps.add(dependency)
+        _dependencies.set(currentDeps)
     }
 }

--- a/plugin/src/main/kotlin/io/github/ttypic/swiftklib/gradle/internal/SwiftPackageConfigurationImpl.kt
+++ b/plugin/src/main/kotlin/io/github/ttypic/swiftklib/gradle/internal/SwiftPackageConfigurationImpl.kt
@@ -26,14 +26,14 @@ internal class SwiftPackageConfigurationImpl @Inject constructor(
 
     @ExperimentalSwiftklibApi
     override fun remote(
-        name: List<String>,
+        names: List<String>,
         configuration: RemotePackageConfiguration.() -> Unit
     ) {
-        val builder = RemotePackageConfigurationImpl(objects, name)
+        val builder = RemotePackageConfigurationImpl(objects, names)
         builder.apply(configuration)
 
         val dependency = builder.build()
-            ?: throw IllegalStateException("No version specification provided for remote package $name")
+            ?: throw IllegalStateException("No version specification provided for remote package $names")
 
         val currentDeps = _dependencies.get().toMutableList()
         currentDeps.add(dependency)

--- a/plugin/src/main/kotlin/io/github/ttypic/swiftklib/gradle/task/CompileSwiftTask.kt
+++ b/plugin/src/main/kotlin/io/github/ttypic/swiftklib/gradle/task/CompileSwiftTask.kt
@@ -86,7 +86,7 @@ abstract class CompileSwiftTask @Inject constructor(
     private val minMacos get() = minMacosProperty.getOrElse("10.13")
     private val minTvos get() = minTvosProperty.getOrElse("12.0")
     private val minWatchos get() = minWatchosProperty.getOrElse("4.0")
-    private val toolsVersion get() = toolsVersionProperty.getOrElse("5.6")
+    private val toolsVersion get() = toolsVersionProperty.getOrElse("5.9")
 
     /**
      * Creates build directory or cleans up if it already exists

--- a/plugin/src/main/kotlin/io/github/ttypic/swiftklib/gradle/task/CompileSwiftTask.kt
+++ b/plugin/src/main/kotlin/io/github/ttypic/swiftklib/gradle/task/CompileSwiftTask.kt
@@ -34,6 +34,7 @@ abstract class CompileSwiftTask @Inject constructor(
     @Optional @Input val minMacosProperty: Property<String>,
     @Optional @Input val minTvosProperty: Property<String>,
     @Optional @Input val minWatchosProperty: Property<String>,
+    @Optional @Input val toolsVersionProperty: Property<String?>,
 ) : DefaultTask() {
 
     @get:Optional
@@ -85,7 +86,7 @@ abstract class CompileSwiftTask @Inject constructor(
     private val minMacos get() = minMacosProperty.getOrElse("10.13")
     private val minTvos get() = minTvosProperty.getOrElse("12.0")
     private val minWatchos get() = minWatchosProperty.getOrElse("4.0")
-
+    private val toolsVersion get() = toolsVersionProperty.get()
     /**
      * Creates build directory or cleans up if it already exists
      * and copies Swift source files to it
@@ -135,6 +136,24 @@ abstract class CompileSwiftTask @Inject constructor(
         }.run {
             if (exitValue != 0) {
                 throw RuntimeException("Failed to init Swift Package")
+            }
+        }
+
+        if (!toolsVersion.isNullOrEmpty()) {
+            execOperations.exec {
+                it.executable = "swift"
+                it.workingDir = swiftBuildDir
+                it.isIgnoreExitValue = true
+                it.args = listOf(
+                    "package",
+                    "tools-version",
+                    "--set",
+                    toolsVersion
+                )
+            }.run {
+                if (exitValue != 0) {
+                    throw RuntimeException("Failed to set the tool version $toolsVersion")
+                }
             }
         }
 

--- a/plugin/src/main/kotlin/io/github/ttypic/swiftklib/gradle/task/CompileSwiftTask.kt
+++ b/plugin/src/main/kotlin/io/github/ttypic/swiftklib/gradle/task/CompileSwiftTask.kt
@@ -34,7 +34,7 @@ abstract class CompileSwiftTask @Inject constructor(
     @Optional @Input val minMacosProperty: Property<String>,
     @Optional @Input val minTvosProperty: Property<String>,
     @Optional @Input val minWatchosProperty: Property<String>,
-    @Optional @Input val toolsVersionProperty: Property<String?>,
+    @Optional @Input val toolsVersionProperty: Property<String>,
 ) : DefaultTask() {
 
     @get:Optional
@@ -86,7 +86,7 @@ abstract class CompileSwiftTask @Inject constructor(
     private val minMacos get() = minMacosProperty.getOrElse("10.13")
     private val minTvos get() = minTvosProperty.getOrElse("12.0")
     private val minWatchos get() = minWatchosProperty.getOrElse("4.0")
-    private val toolsVersion get() = toolsVersionProperty.getOrElse("")
+    private val toolsVersion get() = toolsVersionProperty.getOrElse("5.6")
 
     /**
      * Creates build directory or cleans up if it already exists
@@ -120,20 +120,19 @@ abstract class CompileSwiftTask @Inject constructor(
     }
 
     private fun createPackageSwift(dependencies: List<SwiftPackageDependency>) {
-        createPackageSwiftContents(
+        val manifest = createPackageSwiftContents(
             cinteropName,
             dependencies,
-            execOperations,
-            swiftBuildDir,
             minIos,
             minMacos,
             minTvos,
             minWatchos,
             toolsVersion
         )
+        File(swiftBuildDir, "Package.swift").writeText(manifest)
         if (printDebug) {
             logger.warn("========   Package.swift contents   ========")
-            logger.warn(File(swiftBuildDir, "Package.swift").readText())
+            logger.warn(manifest)
             logger.warn("======== | Package.swift contents | ========")
         }
     }

--- a/plugin/src/main/kotlin/io/github/ttypic/swiftklib/gradle/task/CompileSwiftTask.kt
+++ b/plugin/src/main/kotlin/io/github/ttypic/swiftklib/gradle/task/CompileSwiftTask.kt
@@ -86,7 +86,7 @@ abstract class CompileSwiftTask @Inject constructor(
     private val minMacos get() = minMacosProperty.getOrElse("10.13")
     private val minTvos get() = minTvosProperty.getOrElse("12.0")
     private val minWatchos get() = minWatchosProperty.getOrElse("4.0")
-    private val toolsVersion get() = toolsVersionProperty.get()
+    private val toolsVersion get() = toolsVersionProperty.getOrElse("")
     /**
      * Creates build directory or cleans up if it already exists
      * and copies Swift source files to it
@@ -317,7 +317,7 @@ abstract class CompileSwiftTask @Inject constructor(
         }
 
         val releaseBuildPath =
-            File(swiftBuildDir, ".build/${compileTarget.arch()}-apple-${compileTarget.operatingSystem()}${compileTarget.simulatorSuffix()}/release")
+            File(swiftBuildDir, ".build/${compileTarget.arch()}-apple-${compileTarget.operatingSystem()}${compileTarget.simulatorSuffix()}/debug")
 
         return SwiftBuildResult(
             libPath = File(releaseBuildPath, "lib${cinteropName}.a"),

--- a/plugin/src/main/kotlin/io/github/ttypic/swiftklib/gradle/task/CompileSwiftTask.kt
+++ b/plugin/src/main/kotlin/io/github/ttypic/swiftklib/gradle/task/CompileSwiftTask.kt
@@ -134,7 +134,7 @@ abstract class CompileSwiftTask @Inject constructor(
         if (printDebug) {
             logger.warn("========   Package.swift contents   ========")
             logger.warn(File(swiftBuildDir, "Package.swift").readText())
-            logger.warn("=addPlatformBlock======= | Package.swift contents | ========")
+            logger.warn("======== | Package.swift contents | ========")
         }
     }
 

--- a/plugin/src/main/kotlin/io/github/ttypic/swiftklib/gradle/task/CompileSwiftTask.kt
+++ b/plugin/src/main/kotlin/io/github/ttypic/swiftklib/gradle/task/CompileSwiftTask.kt
@@ -187,25 +187,28 @@ abstract class CompileSwiftTask @Inject constructor(
         }
 
         dependencies.forEach { dependency ->
-            execOperations.exec {
-                it.executable = "swift"
-                it.workingDir = swiftBuildDir
-                it.isIgnoreExitValue = true
-                it.args = listOf(
-                    "package",
-                    "add-target-dependency",
-                    dependency.name,
-                    "--package",
-                    dependency.packageName ?: dependency.name,
-                    cinteropName,
-                )
-            }.run {
-                if (exitValue != 0) {
-                    throw RuntimeException(
-                        "Failed to add Swift Package target dependency $cinteropName - package = ${dependency.name}",
+            dependency.name.forEach { library ->
+                execOperations.exec {
+                    it.executable = "swift"
+                    it.workingDir = swiftBuildDir
+                    it.isIgnoreExitValue = true
+                    it.args = listOf(
+                        "package",
+                        "add-target-dependency",
+                        library,
+                        "--package",
+                        dependency.packageName ?: library,
+                        cinteropName,
                     )
+                }.run {
+                    if (exitValue != 0) {
+                        throw RuntimeException(
+                            "Failed to add Swift Package target dependency $cinteropName - package = ${dependency.packageName ?: library}:$library",
+                        )
+                    }
                 }
             }
+
         }
 
         execOperations.exec {

--- a/plugin/src/main/kotlin/io/github/ttypic/swiftklib/gradle/task/CompileSwiftTask.kt
+++ b/plugin/src/main/kotlin/io/github/ttypic/swiftklib/gradle/task/CompileSwiftTask.kt
@@ -317,7 +317,7 @@ abstract class CompileSwiftTask @Inject constructor(
         }
 
         val releaseBuildPath =
-            File(swiftBuildDir, ".build/${compileTarget.arch()}-apple-${compileTarget.operatingSystem()}${compileTarget.simulatorSuffix()}/debug")
+            File(swiftBuildDir, ".build/${compileTarget.arch()}-apple-${compileTarget.operatingSystem()}${compileTarget.simulatorSuffix()}/release")
 
         return SwiftBuildResult(
             libPath = File(releaseBuildPath, "lib${cinteropName}.a"),

--- a/plugin/src/main/kotlin/io/github/ttypic/swiftklib/gradle/templates/CreatePackageSwift.kt
+++ b/plugin/src/main/kotlin/io/github/ttypic/swiftklib/gradle/templates/CreatePackageSwift.kt
@@ -11,6 +11,7 @@ internal fun SwiftPackageDependency.toSwiftArgs(): List<String> = when (this) {
         if (inclusive) {
             // can't do inclusive range from command line
             // but I think it's better to use up-to-next-minor-from
+            // it needs to be rethink
             listOf(url, "--up-to-next-minor-from", from)
         } else {
             listOf(url, "--from", from, "--to", to)

--- a/plugin/src/main/kotlin/io/github/ttypic/swiftklib/gradle/templates/CreatePackageSwift.kt
+++ b/plugin/src/main/kotlin/io/github/ttypic/swiftklib/gradle/templates/CreatePackageSwift.kt
@@ -2,61 +2,22 @@ package io.github.ttypic.swiftklib.gradle.templates
 
 import io.github.ttypic.swiftklib.gradle.SwiftPackageDependency
 
-internal fun createPackageSwiftContents(
-    cinteropName: String,
-    dependencies: Collection<SwiftPackageDependency>
-): String = """
-    // swift-tools-version:5.6
-    import PackageDescription
-
-    let package = Package(
-        name: "$cinteropName",
-        products: [
-            .library(
-                name: "$cinteropName",
-                type: .static,
-                targets: ["$cinteropName"])
-        ],
-        dependencies: [
-            ${dependencies.joinToString(",\n            ") { it.toSwiftPackageDeclaration() }}
-        ],
-        targets: [
-            .target(
-                name: "$cinteropName",
-                dependencies: [
-                    ${dependencies.joinToString(",\n                    ") { "\"${it.name}\"" }}
-                ],
-                path: "$cinteropName")
-        ]
-    )
-""".trimIndent()
-
-
-internal fun SwiftPackageDependency.toSwiftPackageDeclaration(): String = when (this) {
+internal fun SwiftPackageDependency.toSwiftArgs(): List<String> = when (this) {
     is SwiftPackageDependency.Local ->
-        """
-        .package(path: "${path.absolutePath}")
-        """.trimIndent()
-
+       emptyList()
     is SwiftPackageDependency.Remote.ExactVersion ->
-        """
-        .package(url: "$url", exact: "$version")
-        """.trimIndent()
-
+        listOf(url, "--exact", version)
     is SwiftPackageDependency.Remote.VersionRange -> {
-        val operator = if (inclusive) "..." else "..<"
-        """
-        .package(url: "$url", "$from"$operator"$to")
-        """.trimIndent()
+        if (inclusive) {
+            // can't do inclusive range from command line
+            // but I think it's better to use up-to-next-minor-from
+            listOf(url, "--up-to-next-minor-from", from)
+        } else {
+            listOf(url, "--from", from, "--to", to)
+        }
     }
-
     is SwiftPackageDependency.Remote.Branch ->
-        """
-        .package(url: "$url", branch: "$branchName")
-        """.trimIndent()
-
+        listOf(url, "--branch", branchName)
     is SwiftPackageDependency.Remote.FromVersion ->
-        """
-        .package(url: "$url", from: "$version")
-        """.trimIndent()
+        listOf(url, "--from", version)
 }

--- a/plugin/src/main/kotlin/io/github/ttypic/swiftklib/gradle/templates/CreatePackageSwift.kt
+++ b/plugin/src/main/kotlin/io/github/ttypic/swiftklib/gradle/templates/CreatePackageSwift.kt
@@ -7,207 +7,103 @@ import java.io.File
 internal fun createPackageSwiftContents(
     cinteropName: String,
     dependencies: Collection<SwiftPackageDependency>,
-    execOperations: ExecOperations,
-    swiftBuildDir: File,
     minIos: String,
     minMacos: String,
     minTvos: String,
     minWatchos: String,
-    toolsVersion: String?,
-) {
-    execOperations.exec {
-        it.executable = "swift"
-        it.workingDir = swiftBuildDir
-        it.isIgnoreExitValue = true
-        it.args = listOf(
-            "package",
-            "init",
-            "--name",
-            cinteropName,
-            "--type",
-            "empty",
-            "--disable-xctest",
-            "--disable-swift-testing"
-        )
-    }.run {
-        if (exitValue != 0) {
-            throw RuntimeException("Failed to init Swift Package")
-        }
-    }
+    toolsVersion: String,
+): String = """
+    // swift-tools-version: $toolsVersion
+    import PackageDescription
 
-    if (!toolsVersion.isNullOrEmpty()) {
-        execOperations.exec {
-            it.executable = "swift"
-            it.workingDir = swiftBuildDir
-            it.isIgnoreExitValue = true
-            it.args = listOf(
-                "package",
-                "tools-version",
-                "--set",
-                toolsVersion
-            )
-        }.run {
-            if (exitValue != 0) {
-                throw RuntimeException("Failed to set the tool version $toolsVersion")
-            }
-        }
-    }
+    let package = Package(
+        name: "$cinteropName",
+        ${getPlatformBlock(minIos, minMacos, minTvos, minWatchos)},
+        products: [
+            .library(
+                name: "$cinteropName",
+                type: .static,
+                targets: ${getProductsTargets(cinteropName)})
+        ],
+        dependencies: [
+            ${getDependencies(dependencies)}
+        ],
+        targets: [
+            .target(
+                name: "$cinteropName",
+                dependencies: [
+                    ${getDependenciesTargets(dependencies)}
+                ],
+                path: "$cinteropName")
+        ]
+    )
+""".trimIndent()
 
-    dependencies.forEach { dependency ->
-        if (dependency is SwiftPackageDependency.Local) {
-            addDependencyBlockIfNeeded(cinteropName, swiftBuildDir)
-            val escapePath = dependency.path.absolutePath.replace("/", "\\/")
-            execOperations.exec {
-                it.executable = "sed"
-                it.workingDir = swiftBuildDir
-                it.args = listOf(
-                    "-i",
-                    "''",
-                    "/dependencies: \\[/,/]/ s/]/    \\n\\t.package(path: \"${escapePath}\"),\\n]/",
-                    "Package.swift"
-                )
-                it.isIgnoreExitValue = true
-            }
-        } else {
-            execOperations.exec {
-                it.executable = "swift"
-                it.workingDir = swiftBuildDir
-                it.args = listOf("package", "add-dependency") + dependency.toSwiftArgs()
-                it.isIgnoreExitValue = true
-            }
-        }.run {
-            if (exitValue != 0) {
-                throw RuntimeException(
-                    "Failed to add Swift Package dependency $dependency",
-                )
-            }
-        }
-    }
-    addPlatformBlock(cinteropName, swiftBuildDir, minIos, minMacos, minTvos, minWatchos)
-    execOperations.exec {
-        it.executable = "swift"
-        it.workingDir = swiftBuildDir
-        it.args = listOf(
-            "package",
-            "add-target",
-            "--path",
-            cinteropName,
-            cinteropName
-        )
-        it.isIgnoreExitValue = true
-    }.run {
-        if (exitValue != 0) {
-            throw RuntimeException("Failed to add Swift Package target $cinteropName")
-        }
-    }
-
-    dependencies.forEach { dependency ->
-        dependency.name.forEach { library ->
-            execOperations.exec {
-                it.executable = "swift"
-                it.workingDir = swiftBuildDir
-                it.isIgnoreExitValue = true
-                it.args = listOf(
-                    "package",
-                    "add-target-dependency",
-                    library,
-                    "--package",
-                    dependency.packageName ?: library,
-                    cinteropName,
-                )
-            }.run {
-                if (exitValue != 0) {
-                    throw RuntimeException(
-                        "Failed to add Swift Package target dependency $cinteropName - package = ${dependency.packageName ?: library}:$library",
-                    )
-                }
-            }
-        }
-
-    }
-
-    execOperations.exec {
-        it.executable = "swift"
-        it.workingDir = swiftBuildDir
-        it.isIgnoreExitValue = true
-        it.args = listOf(
-            "package",
-            "add-product",
-            "--targets",
-            cinteropName,
-            "--type",
-            "static-library",
-            cinteropName
-        )
-    }.run {
-        if (exitValue != 0) {
-            throw RuntimeException(
-                "Failed to add Swift Package library $cinteropName",
-            )
-        }
-    }
-
-}
-
-
-internal fun SwiftPackageDependency.toSwiftArgs(): List<String> = when (this) {
-    is SwiftPackageDependency.Local ->
-        emptyList()
-
-    is SwiftPackageDependency.Remote.ExactVersion ->
-        listOf(url, "--exact", version)
-
-    is SwiftPackageDependency.Remote.VersionRange -> {
-        if (inclusive) {
-            // can't do inclusive range from command line
-            // but I think it's better to use up-to-next-minor-from
-            // it needs to be rethink
-            listOf(url, "--up-to-next-minor-from", from)
-        } else {
-            listOf(url, "--from", from, "--to", to)
-        }
-    }
-
-    is SwiftPackageDependency.Remote.Branch ->
-        listOf(url, "--branch", branchName)
-
-    is SwiftPackageDependency.Remote.FromVersion ->
-        listOf(url, "--from", version)
-}
-
-private fun addDependencyBlockIfNeeded(name: String, swiftBuildDir: File) {
-    File(swiftBuildDir, "Package.swift").readText().run {
-        if (!contains("dependencies:")) {
-            val updated = replace("name: \"$name\"", "name: \"$name\",\n\tdependencies: []")
-            File(swiftBuildDir, "Package.swift").writeText(updated)
-        }
-    }
-}
-
-private fun addPlatformBlock(
-    name: String,
-    swiftBuildDir: File,
+private fun getPlatformBlock(
     minIos: String,
     minMacos: String,
     minTvos: String,
     minWatchos: String
-) {
-    File(swiftBuildDir, "Package.swift").readText().run {
-        if (!contains("platforms:")) {
-            val entries = listOfNotNull(
-                ".iOS(\"$minIos\")".takeIf { minIos.isNotEmpty() },
-                ".macOS(\"$minMacos\")".takeIf { minMacos.isNotEmpty() },
-                ".tvOS(\"$minTvos\")".takeIf { minTvos.isNotEmpty() },
-                ".watchOS(\"$minWatchos\")".takeIf { minWatchos.isNotEmpty() },
-            ).joinToString(",")
-            if (entries.isNotEmpty()) {
-                val updated =
-                    replace(
-                        "name: \"$name\",\n",
-                        "name: \"$name\",\n\tplatforms: [$entries],\n"
-                    )
-                File(swiftBuildDir, "Package.swift").writeText(updated)
+): String {
+    val entries = listOfNotNull(
+        ".iOS(\"$minIos\")".takeIf { minIos.isNotEmpty() },
+        ".macOS(\"$minMacos\")".takeIf { minMacos.isNotEmpty() },
+        ".tvOS(\"$minTvos\")".takeIf { minTvos.isNotEmpty() },
+        ".watchOS(\"$minWatchos\")".takeIf { minWatchos.isNotEmpty() },
+    ).joinToString(",")
+    return "platforms: [$entries]"
+}
+
+private fun getDependencies(dependencies: Collection<SwiftPackageDependency>): String {
+    return buildList {
+        dependencies.forEach { dependency ->
+            add(dependency.toSwiftPackageDependencyDeclaration())
+        }
+    }.joinToString(",")
+}
+
+private fun SwiftPackageDependency.toSwiftPackageDependencyDeclaration(): String = when (this) {
+    is SwiftPackageDependency.Local ->
+        """
+        .package(path: "${path.absolutePath}")
+        """.trimIndent()
+
+    is SwiftPackageDependency.Remote.ExactVersion ->
+        """
+        .package(url: "$url", exact: "$version")
+        """.trimIndent()
+
+    is SwiftPackageDependency.Remote.VersionRange -> {
+        val operator = if (inclusive) "..." else "..<"
+        """
+        .package(url: "$url", "$from"$operator"$to")
+        """.trimIndent()
+    }
+
+    is SwiftPackageDependency.Remote.Branch ->
+        """
+        .package(url: "$url", branch: "$branchName")
+        """.trimIndent()
+
+    is SwiftPackageDependency.Remote.FromVersion ->
+        """
+        .package(url: "$url", from: "$version")
+        """.trimIndent()
+}
+
+
+private fun getDependenciesTargets(
+    dependencies: Collection<SwiftPackageDependency>
+): String {
+    return buildList {
+        dependencies.forEach { dependency ->
+            dependency.name.forEach { library ->
+                add(".product(name: \"${library}\", package: \"${dependency.packageName ?: library}\")")
             }
         }
-    }
+    }.joinToString(",")
+}
+
+private fun getProductsTargets(cinteropName: String): String {
+    return "[\"$cinteropName\"]"
 }

--- a/plugin/src/main/kotlin/io/github/ttypic/swiftklib/gradle/templates/CreatePackageSwift.kt
+++ b/plugin/src/main/kotlin/io/github/ttypic/swiftklib/gradle/templates/CreatePackageSwift.kt
@@ -1,12 +1,162 @@
 package io.github.ttypic.swiftklib.gradle.templates
 
 import io.github.ttypic.swiftklib.gradle.SwiftPackageDependency
+import org.gradle.process.ExecOperations
+import java.io.File
+
+internal fun createPackageSwiftContents(
+    cinteropName: String,
+    dependencies: Collection<SwiftPackageDependency>,
+    execOperations: ExecOperations,
+    swiftBuildDir: File,
+    minIos: String,
+    minMacos: String,
+    minTvos: String,
+    minWatchos: String,
+    toolsVersion: String?,
+) {
+    execOperations.exec {
+        it.executable = "swift"
+        it.workingDir = swiftBuildDir
+        it.isIgnoreExitValue = true
+        it.args = listOf(
+            "package",
+            "init",
+            "--name",
+            cinteropName,
+            "--type",
+            "empty",
+            "--disable-xctest",
+            "--disable-swift-testing"
+        )
+    }.run {
+        if (exitValue != 0) {
+            throw RuntimeException("Failed to init Swift Package")
+        }
+    }
+
+    if (!toolsVersion.isNullOrEmpty()) {
+        execOperations.exec {
+            it.executable = "swift"
+            it.workingDir = swiftBuildDir
+            it.isIgnoreExitValue = true
+            it.args = listOf(
+                "package",
+                "tools-version",
+                "--set",
+                toolsVersion
+            )
+        }.run {
+            if (exitValue != 0) {
+                throw RuntimeException("Failed to set the tool version $toolsVersion")
+            }
+        }
+    }
+
+    dependencies.forEach { dependency ->
+        if (dependency is SwiftPackageDependency.Local) {
+            addDependencyBlockIfNeeded(cinteropName, swiftBuildDir)
+            val escapePath = dependency.path.absolutePath.replace("/", "\\/")
+            execOperations.exec {
+                it.executable = "sed"
+                it.workingDir = swiftBuildDir
+                it.args = listOf(
+                    "-i",
+                    "''",
+                    "/dependencies: \\[/,/]/ s/]/    \\n\\t.package(path: \"${escapePath}\"),\\n]/",
+                    "Package.swift"
+                )
+                it.isIgnoreExitValue = true
+            }
+        } else {
+            execOperations.exec {
+                it.executable = "swift"
+                it.workingDir = swiftBuildDir
+                it.args = listOf("package", "add-dependency") + dependency.toSwiftArgs()
+                it.isIgnoreExitValue = true
+            }
+        }.run {
+            if (exitValue != 0) {
+                throw RuntimeException(
+                    "Failed to add Swift Package dependency $dependency",
+                )
+            }
+        }
+    }
+    addPlatformBlock(cinteropName, swiftBuildDir, minIos, minMacos, minTvos, minWatchos)
+    execOperations.exec {
+        it.executable = "swift"
+        it.workingDir = swiftBuildDir
+        it.args = listOf(
+            "package",
+            "add-target",
+            "--path",
+            cinteropName,
+            cinteropName
+        )
+        it.isIgnoreExitValue = true
+    }.run {
+        if (exitValue != 0) {
+            throw RuntimeException("Failed to add Swift Package target $cinteropName")
+        }
+    }
+
+    dependencies.forEach { dependency ->
+        dependency.name.forEach { library ->
+            execOperations.exec {
+                it.executable = "swift"
+                it.workingDir = swiftBuildDir
+                it.isIgnoreExitValue = true
+                it.args = listOf(
+                    "package",
+                    "add-target-dependency",
+                    library,
+                    "--package",
+                    dependency.packageName ?: library,
+                    cinteropName,
+                )
+            }.run {
+                if (exitValue != 0) {
+                    throw RuntimeException(
+                        "Failed to add Swift Package target dependency $cinteropName - package = ${dependency.packageName ?: library}:$library",
+                    )
+                }
+            }
+        }
+
+    }
+
+    execOperations.exec {
+        it.executable = "swift"
+        it.workingDir = swiftBuildDir
+        it.isIgnoreExitValue = true
+        it.args = listOf(
+            "package",
+            "add-product",
+            "--targets",
+            cinteropName,
+            "--type",
+            "static-library",
+            cinteropName
+        )
+    }.run {
+        if (exitValue != 0) {
+            throw RuntimeException(
+                "Failed to add Swift Package library $cinteropName",
+            )
+        }
+    }
+
+}
+
 
 internal fun SwiftPackageDependency.toSwiftArgs(): List<String> = when (this) {
     is SwiftPackageDependency.Local ->
-       emptyList()
+        emptyList()
+
     is SwiftPackageDependency.Remote.ExactVersion ->
         listOf(url, "--exact", version)
+
     is SwiftPackageDependency.Remote.VersionRange -> {
         if (inclusive) {
             // can't do inclusive range from command line
@@ -17,8 +167,47 @@ internal fun SwiftPackageDependency.toSwiftArgs(): List<String> = when (this) {
             listOf(url, "--from", from, "--to", to)
         }
     }
+
     is SwiftPackageDependency.Remote.Branch ->
         listOf(url, "--branch", branchName)
+
     is SwiftPackageDependency.Remote.FromVersion ->
         listOf(url, "--from", version)
+}
+
+private fun addDependencyBlockIfNeeded(name: String, swiftBuildDir: File) {
+    File(swiftBuildDir, "Package.swift").readText().run {
+        if (!contains("dependencies:")) {
+            val updated = replace("name: \"$name\"", "name: \"$name\",\n\tdependencies: []")
+            File(swiftBuildDir, "Package.swift").writeText(updated)
+        }
+    }
+}
+
+private fun addPlatformBlock(
+    name: String,
+    swiftBuildDir: File,
+    minIos: String,
+    minMacos: String,
+    minTvos: String,
+    minWatchos: String
+) {
+    File(swiftBuildDir, "Package.swift").readText().run {
+        if (!contains("platforms:")) {
+            val entries = listOfNotNull(
+                ".iOS(\"$minIos\")".takeIf { minIos.isNotEmpty() },
+                ".macOS(\"$minMacos\")".takeIf { minMacos.isNotEmpty() },
+                ".tvOS(\"$minTvos\")".takeIf { minTvos.isNotEmpty() },
+                ".watchOS(\"$minWatchos\")".takeIf { minWatchos.isNotEmpty() },
+            ).joinToString(",")
+            if (entries.isNotEmpty()) {
+                val updated =
+                    replace(
+                        "name: \"$name\",\n",
+                        "name: \"$name\",\n\tplatforms: [$entries],\n"
+                    )
+                File(swiftBuildDir, "Package.swift").writeText(updated)
+            }
+        }
+    }
 }


### PR DESCRIPTION
Based on #47

- Using the command line instead of String manipulation
- Adding local spm can't be done by command line, so I did it manually
- Adding platforms can't be done by command line, so I did it manually
- Adding complex package support (like firebase : see tests)
- Adding toolsVersion 
- simplify the swift build command

See the new tests for new features

To be done : change the way the version of a spm is set, the command line has limited possibility.